### PR TITLE
feat(auth): add Linux support for Claude CLI credentials

### DIFF
--- a/lib/claude-cli-auth.ts
+++ b/lib/claude-cli-auth.ts
@@ -1,4 +1,7 @@
 import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
 import Anthropic from '@anthropic-ai/sdk'
 
 interface ClaudeOAuthCredentials {
@@ -10,17 +13,26 @@ interface ClaudeOAuthCredentials {
 }
 
 /**
- * Reads Claude Code CLI credentials from the macOS keychain.
- * Returns null if not on macOS, CLI not installed, or not logged in.
+ * Reads Claude Code CLI credentials.
+ * - macOS: reads from the system keychain
+ * - Linux: reads from ~/.claude/.credentials.json
+ * Returns null if CLI not installed or not logged in.
  */
 function readCliCredentials(): ClaudeOAuthCredentials | null {
-  if (process.platform !== 'darwin') return null
-
   try {
-    const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null', {
-      encoding: 'utf8',
-      timeout: 3000,
-    }).trim()
+    let raw: string | null = null
+
+    if (process.platform === 'darwin') {
+      raw = execSync('security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null', {
+        encoding: 'utf8',
+        timeout: 3000,
+      }).trim()
+    } else if (process.platform === 'linux') {
+      const credPath = join(homedir(), '.claude', '.credentials.json')
+      raw = readFileSync(credPath, 'utf8').trim()
+    } else {
+      return null
+    }
 
     if (!raw) return null
 
@@ -29,7 +41,8 @@ function readCliCredentials(): ClaudeOAuthCredentials | null {
     if (!oauth?.accessToken) return null
 
     return oauth as ClaudeOAuthCredentials
-  } catch {
+  } catch (err) {
+    console.warn('[claude-cli-auth] Failed to read credentials:', err instanceof Error ? err.message : err)
     return null
   }
 }
@@ -79,8 +92,6 @@ export function getCliAuthStatus(): {
   subscriptionType?: string
   expired?: boolean
 } {
-  if (process.platform !== 'darwin') return { available: false }
-
   const creds = readCliCredentials()
   if (!creds) return { available: false }
 


### PR DESCRIPTION
## Summary
- Add Linux credential reading from `~/.claude/.credentials.json` (previously macOS-only via keychain)
- Explicitly return `null` on unsupported platforms instead of falling through
- Add `console.warn` on credential read failures for debuggability

## Changes
- `lib/claude-cli-auth.ts`: Platform-specific branching for `darwin` (keychain) and `linux` (filesystem)

## Test plan
- [ ] Verify CLI auth works on Linux with `~/.claude/.credentials.json` present
- [ ] Verify CLI auth still works on macOS via keychain
- [ ] Verify unsupported platforms (Windows) return `null` gracefully
- [ ] Verify `GET /api/settings/cli-status` reflects correct auth state

🤖 Generated with [Claude Code](https://claude.com/claude-code)