### PR TITLE
feat: add liked tweets import and source filtering

### DIFF
--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -34,6 +34,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(request.url)
 
   const q = searchParams.get('q')?.trim() ?? ''
+  const source = searchParams.get('source')?.trim() ?? ''
   const categorySlug = searchParams.get('category')?.trim() ?? ''
   const mediaType = searchParams.get('mediaType')?.trim() ?? ''
   const uncategorized = searchParams.get('uncategorized') === 'true'
@@ -44,6 +45,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const orderDir = sortParam === 'oldest' ? 'asc' : 'desc'
 
   const where: Record<string, unknown> = {}
+
+  if (source === 'bookmark' || source === 'like') {
+    where.source = source
+  }
 
   if (q) {
     where.text = { contains: q }
@@ -97,6 +102,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       text: bookmark.text,
       authorHandle: bookmark.authorHandle,
       authorName: bookmark.authorName,
+      source: bookmark.source,
       tweetCreatedAt: bookmark.tweetCreatedAt?.toISOString() ?? null,
       importedAt: bookmark.importedAt.toISOString(),
       mediaItems: bookmark.mediaItems.map((m) => ({

--- a/app/api/import/bookmarklet/route.ts
+++ b/app/api/import/bookmarklet/route.ts
@@ -64,13 +64,14 @@ function extractMedia(tweet: TweetResult) {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  let body: { tweets?: TweetResult[] } = {}
+  let body: { tweets?: TweetResult[]; source?: string } = {}
   try {
     body = await request.json()
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400, headers: CORS })
   }
 
+  const source = body.source === 'like' ? 'like' : 'bookmark'
   const tweets = body.tweets ?? []
   if (!Array.isArray(tweets) || tweets.length === 0) {
     return NextResponse.json({ error: 'No tweets provided' }, { status: 400, headers: CORS })
@@ -105,6 +106,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           ? new Date(tweet.legacy.created_at)
           : null,
         rawJson: JSON.stringify(tweet),
+        source,
       },
     })
 

--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -10,6 +10,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Failed to parse form data' }, { status: 400 })
   }
 
+  const sourceParam = (formData.get('source') as string | null)?.trim()
   const file = formData.get('file')
   if (!file || !(file instanceof Blob)) {
     return NextResponse.json(
@@ -55,6 +56,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     )
   }
 
+  // Determine source: formData param > JSON field > default "bookmark"
+  let jsonSource: string | undefined
+  try {
+    const parsed = JSON.parse(jsonString)
+    if (typeof parsed?.source === 'string') jsonSource = parsed.source
+  } catch { /* already parsed above */ }
+  const source = (sourceParam === 'like' || sourceParam === 'bookmark')
+    ? sourceParam
+    : (jsonSource === 'like' ? 'like' : 'bookmark')
+
   await prisma.importJob.update({
     where: { id: importJob.id },
     data: { totalCount: parsedBookmarks.length },
@@ -83,6 +94,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           authorName: bookmark.authorName,
           tweetCreatedAt: bookmark.tweetCreatedAt,
           rawJson: bookmark.rawJson,
+          source,
         },
       })
 

--- a/app/api/import/twitter/route.ts
+++ b/app/api/import/twitter/route.ts
@@ -25,9 +25,36 @@ const FEATURES = JSON.stringify({
   responsive_web_enhance_cards_enabled: false,
 })
 
-// Query ID for Twitter's internal Bookmarks GraphQL endpoint
-// This can change when Twitter deploys updates — update if you get 400 errors
-const QUERY_ID = 'j5KExFXy1niL_uGnBhHNxA'
+// Query IDs for Twitter's internal GraphQL endpoints
+// These can change when Twitter deploys updates — update if you get 400 errors
+//
+// To find the Likes query ID: open x.com/<username>/likes with DevTools Network tab,
+// filter by "graphql", find the "Likes" request, and grab the ID from the URL path.
+const ENDPOINTS = {
+  bookmark: {
+    queryId: 'j5KExFXy1niL_uGnBhHNxA',
+    operationName: 'Bookmarks',
+    referer: 'https://x.com/i/bookmarks',
+    getInstructions: (d: Record<string, unknown>): unknown[] =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (d as any)?.data?.bookmark_timeline_v2?.timeline?.instructions ?? [],
+  },
+  like: {
+    // PLACEHOLDER — you must replace this with the real query ID from x.com Network tab
+    queryId: 'REPLACE_ME',
+    operationName: 'Likes',
+    referer: 'https://x.com',
+    getInstructions: (d: Record<string, unknown>): unknown[] => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const a = d as any
+      return a?.data?.user?.result?.timeline_v2?.timeline?.instructions
+        ?? a?.data?.liked_tweets_timeline?.timeline?.instructions
+        ?? []
+    },
+  },
+} as const
+
+type Source = keyof typeof ENDPOINTS
 
 interface MediaVariant {
   content_type?: string
@@ -59,14 +86,16 @@ interface TweetResult {
   core?: { user_results?: { result?: { legacy?: UserLegacy } } }
 }
 
-async function fetchPage(authToken: string, ct0: string, cursor?: string) {
+async function fetchPage(authToken: string, ct0: string, source: Source, cursor?: string, userId?: string) {
+  const cfg = ENDPOINTS[source]
   const variables = JSON.stringify({
     count: 100,
     includePromotedContent: false,
+    ...(source === 'like' && userId ? { userId } : {}),
     ...(cursor ? { cursor } : {}),
   })
 
-  const url = `https://x.com/i/api/graphql/${QUERY_ID}/Bookmarks?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(FEATURES)}`
+  const url = `https://x.com/i/api/graphql/${cfg.queryId}/${cfg.operationName}?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(FEATURES)}`
 
   const res = await fetch(url, {
     headers: {
@@ -79,7 +108,7 @@ async function fetchPage(authToken: string, ct0: string, cursor?: string) {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
       Accept: '*/*',
       'Accept-Language': 'en-US,en;q=0.9',
-      Referer: 'https://x.com/i/bookmarks',
+      Referer: cfg.referer,
     },
   })
 
@@ -91,17 +120,16 @@ async function fetchPage(authToken: string, ct0: string, cursor?: string) {
   return res.json()
 }
 
-function parsePage(data: unknown): { tweets: TweetResult[]; nextCursor: string | null } {
-  const instructions =
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (data as any)?.data?.bookmark_timeline_v2?.timeline?.instructions ?? []
+function parsePage(data: unknown, source: Source): { tweets: TweetResult[]; nextCursor: string | null } {
+  const instructions = ENDPOINTS[source].getInstructions(data as Record<string, unknown>)
 
   const tweets: TweetResult[] = []
   let nextCursor: string | null = null
 
-  for (const instruction of instructions) {
+  for (const instruction of instructions as Array<Record<string, unknown>>) {
     if (instruction.type !== 'TimelineAddEntries') continue
-    for (const entry of instruction.entries ?? []) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const entry of (instruction as any).entries ?? []) {
       const content = entry.content
       if (content?.entryType === 'TimelineTimelineItem') {
         const tweet: TweetResult = content?.itemContent?.tweet_results?.result
@@ -143,7 +171,7 @@ function extractMedia(tweet: TweetResult) {
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  let body: { authToken?: string; ct0?: string } = {}
+  let body: { authToken?: string; ct0?: string; source?: string; userId?: string } = {}
   try {
     body = await request.json()
   } catch {
@@ -151,8 +179,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const { authToken, ct0 } = body
+  const source: Source = body.source === 'like' ? 'like' : 'bookmark'
+  const userId = body.userId?.trim()
+
   if (!authToken?.trim() || !ct0?.trim()) {
     return NextResponse.json({ error: 'authToken and ct0 are required' }, { status: 400 })
+  }
+
+  if (source === 'like' && !userId) {
+    return NextResponse.json({ error: 'userId is required for importing likes' }, { status: 400 })
   }
 
   let imported = 0
@@ -161,8 +196,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   try {
     while (true) {
-      const data = await fetchPage(authToken.trim(), ct0.trim(), cursor)
-      const { tweets, nextCursor } = parsePage(data)
+      const data = await fetchPage(authToken.trim(), ct0.trim(), source, cursor, userId)
+      const { tweets, nextCursor } = parsePage(data, source)
 
       for (const tweet of tweets) {
         if (!tweet.rest_id) continue
@@ -190,6 +225,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
               ? new Date(tweet.legacy.created_at)
               : null,
             rawJson: JSON.stringify(tweet),
+            source,
           },
         })
 

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -5,12 +5,16 @@ export async function GET(): Promise<NextResponse> {
   try {
     const [
       totalBookmarks,
+      bookmarkCount,
+      likeCount,
       totalCategories,
       totalMedia,
       recentBookmarks,
       topCategoriesRaw,
     ] = await Promise.all([
       prisma.bookmark.count(),
+      prisma.bookmark.count({ where: { source: 'bookmark' } }),
+      prisma.bookmark.count({ where: { source: 'like' } }),
       prisma.category.count(),
       prisma.mediaItem.count(),
       prisma.bookmark.findMany({
@@ -67,6 +71,8 @@ export async function GET(): Promise<NextResponse> {
 
     return NextResponse.json({
       totalBookmarks,
+      bookmarkCount,
+      likeCount,
       totalCategories,
       totalMedia,
       recentBookmarks: formattedRecent,

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -23,6 +23,7 @@ interface Filters {
   q: string
   category: string
   mediaType: string
+  source: string
   sort: string
   page: number
   uncategorized: boolean
@@ -32,6 +33,7 @@ const DEFAULT_FILTERS: Filters = {
   q: '',
   category: '',
   mediaType: '',
+  source: '',
   sort: 'newest',
   page: 1,
   uncategorized: false,
@@ -46,6 +48,7 @@ function buildUrl(filters: Filters): string {
     params.set('category', filters.category)
   }
   if (filters.mediaType) params.set('mediaType', filters.mediaType)
+  if (filters.source) params.set('source', filters.source)
   params.set('sort', filters.sort)
   params.set('page', String(filters.page))
   params.set('limit', String(PAGE_SIZE))
@@ -252,12 +255,17 @@ function BookmarksPageInner() {
     { label: 'Videos', value: 'video' },
   ]
 
+  const sourceOptions = [
+    { label: 'Bookmarks', value: 'bookmark' },
+    { label: 'Likes', value: 'like' },
+  ]
+
   const sortOptions = [
     { label: 'Newest first', value: 'newest' },
     { label: 'Oldest first', value: 'oldest' },
   ]
 
-  const hasActiveFilters = !!(filters.q || filters.category || filters.mediaType || filters.sort !== 'newest' || filters.uncategorized)
+  const hasActiveFilters = !!(filters.q || filters.category || filters.mediaType || filters.source || filters.sort !== 'newest' || filters.uncategorized)
 
   const sortLabel = sortOptions.find((o) => o.value === filters.sort)?.label ?? 'Newest first'
 
@@ -295,6 +303,14 @@ function BookmarksPageInner() {
               onChange={(v) => updateFilter('mediaType', v)}
               options={mediaOptions}
               placeholder="All media"
+            />
+
+            {/* Source */}
+            <SelectMenu
+              value={filters.source}
+              onChange={(v) => updateFilter('source', v)}
+              options={sourceOptions}
+              placeholder="All sources"
             />
 
             {/* Sort */}
@@ -350,6 +366,12 @@ function BookmarksPageInner() {
                 <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-indigo-500/10 border border-indigo-500/20 text-indigo-300 text-xs font-medium">
                   {mediaOptions.find((o) => o.value === filters.mediaType)?.label}
                   <button onClick={() => updateFilter('mediaType', '')} className="text-indigo-400 hover:text-indigo-200 transition-colors"><X size={10} /></button>
+                </span>
+              )}
+              {filters.source && (
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-indigo-500/10 border border-indigo-500/20 text-indigo-300 text-xs font-medium">
+                  {sourceOptions.find((o) => o.value === filters.source)?.label}
+                  <button onClick={() => updateFilter('source', '')} className="text-indigo-400 hover:text-indigo-200 transition-colors"><X size={10} /></button>
                 </span>
               )}
               {filters.sort !== 'newest' && (

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -65,8 +65,11 @@ const STAGE_INFO: Record<NonNullable<Stage>, { label: string; icon: React.ReactN
 
 const BOOKMARKLET_SCRIPT = `(async function(){
   if(!location.hostname.includes('twitter.com')&&!location.hostname.includes('x.com')){
-    showToast('\u274c Please navigate to x.com/i/bookmarks first','#ef4444');return;
+    showToast('\u274c Please navigate to x.com/i/bookmarks or x.com/username/likes first','#ef4444');return;
   }
+  var isLikes=location.pathname.includes('/likes');
+  var source=isLikes?'like':'bookmark';
+  var label=isLikes?'likes':'bookmarks';
   function showToast(msg,bg){
     var t=document.createElement('div');t.innerHTML=msg;
     Object.assign(t.style,{position:'fixed',bottom:'24px',left:'50%',transform:'translateX(-50%)',
@@ -79,7 +82,7 @@ const BOOKMARKLET_SCRIPT = `(async function(){
   }
   var all=[],seen=new Set();
   var btn=document.createElement('button');
-  btn.textContent='Scroll, then Export 0 bookmarks \u2192';
+  btn.textContent='Scroll, then Export 0 '+label+' \u2192';
   Object.assign(btn.style,{position:'fixed',top:'12px',right:'12px',zIndex:'2147483647',
     padding:'10px 18px',background:'#4f46e5',color:'#fff',border:'none',borderRadius:'8px',
     cursor:'pointer',fontSize:'14px',fontWeight:'700',
@@ -107,7 +110,7 @@ const BOOKMARKLET_SCRIPT = `(async function(){
       text:leg.full_text||leg.text||'',media:media,
       hashtags:(leg.entities&&leg.entities.hashtags||[]).map(function(h){return h.text;}),
       urls:(leg.entities&&leg.entities.urls||[]).map(function(u){return u.expanded_url;}).filter(Boolean)});
-    btn.textContent='Export '+all.length+' bookmarks \u2192';
+    btn.textContent='Export '+all.length+' '+label+' \u2192';
   }
   function processEntry(e){
     if(!e)return;
@@ -118,11 +121,15 @@ const BOOKMARKLET_SCRIPT = `(async function(){
     }
     if(e.content&&e.content.items)e.content.items.forEach(function(i){processEntry({content:i.item||i});});
   }
+  function findInstructions(obj,depth){
+    if(!obj||typeof obj!=='object'||depth>6)return null;
+    if(Array.isArray(obj))return null;
+    if(Array.isArray(obj.instructions))return obj.instructions;
+    for(var k in obj){if(Object.prototype.hasOwnProperty.call(obj,k)){var r=findInstructions(obj[k],depth+1);if(r)return r;}}
+    return null;
+  }
   function processData(d){
-    var instr=
-      (d&&d.data&&d.data.bookmark_timeline_v2&&d.data.bookmark_timeline_v2.timeline&&d.data.bookmark_timeline_v2.timeline.instructions)||
-      (d&&d.data&&d.data.bookmarks_timeline&&d.data.bookmarks_timeline.timeline&&d.data.bookmarks_timeline.timeline.instructions)||
-      (d&&d.data&&d.data.timeline_by_id&&d.data.timeline_by_id.timeline&&d.data.timeline_by_id.timeline.instructions)||[];
+    var instr=findInstructions(d,0)||[];
     instr.forEach(function(i){(i.entries||[]).forEach(processEntry);(i.moduleItems||[]).forEach(processEntry);});
   }
   var autoBtn=document.createElement('button');
@@ -130,13 +137,13 @@ const BOOKMARKLET_SCRIPT = `(async function(){
     window.fetch=origFetch;
     XMLHttpRequest.prototype.open=origOpen;
     XMLHttpRequest.prototype.send=origSend;
-    if(!all.length){showToast('\u26a0\ufe0f No bookmarks captured \u2014 scroll or use Auto-scroll first!','#92400e');return;}
+    if(!all.length){showToast('\u26a0\ufe0f No '+label+' captured \u2014 scroll or use Auto-scroll first!','#92400e');return;}
     [btn,autoBtn].forEach(function(el){try{document.body.removeChild(el);}catch(e){}});
-    var blob=new Blob([JSON.stringify({bookmarks:all},null,2)],{type:'application/json'});
+    var blob=new Blob([JSON.stringify({bookmarks:all,source:source},null,2)],{type:'application/json'});
     var url=URL.createObjectURL(blob);
-    var a=document.createElement('a');a.href=url;a.download='bookmarks.json';a.click();
+    var a=document.createElement('a');a.href=url;a.download=source+'s.json';a.click();
     setTimeout(function(){URL.revokeObjectURL(url);},1000);
-    showToast('\u2705 Downloaded '+all.length+' bookmarks! Upload to Siftly.','#14532d');
+    showToast('\u2705 Downloaded '+all.length+' '+label+'! Upload to Siftly.','#14532d');
   }
   btn.onclick=doExport;
   autoBtn.textContent='\u25b6 Auto-scroll';
@@ -163,7 +170,7 @@ const BOOKMARKLET_SCRIPT = `(async function(){
             autoScrolling=false;
             autoBtn.textContent='\u2705 Done \u2014 '+all.length+' captured';
             autoBtn.style.background='#14532d';autoBtn.style.color='#86efac';autoBtn.style.border='1px solid #166534';
-            showToast('\u2705 Auto-scroll complete! '+all.length+' bookmarks ready. Click Export.','#14532d');
+            showToast('\u2705 Auto-scroll complete! '+all.length+' '+label+' ready. Click Export.','#14532d');
             return;
           }
           stagnant=0;
@@ -187,7 +194,7 @@ const BOOKMARKLET_SCRIPT = `(async function(){
     var r=await origFetch.apply(this,arguments);
     try{
       var u=arguments[0] instanceof Request?arguments[0].url:String(arguments[0]);
-      if(u.toLowerCase().includes('bookmark')){var d=await r.clone().json();processData(d);}
+      if(u.includes('/graphql/')){var d=await r.clone().json();processData(d);}
     }catch(ex){}
     return r;
   };
@@ -195,18 +202,21 @@ const BOOKMARKLET_SCRIPT = `(async function(){
   XMLHttpRequest.prototype.open=function(){xhrUrls.set(this,String(arguments[1]||''));return origOpen.apply(this,arguments);};
   XMLHttpRequest.prototype.send=function(){
     var xhr=this,u=xhrUrls.get(xhr)||'';
-    if(u.toLowerCase().includes('bookmark')){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
+    if(u.includes('/graphql/')){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
     return origSend.apply(this,arguments);
   };
-  showToast('\u2705 Active! Scroll your bookmarks \u2014 counter updates above.','#1e1b4b');
+  showToast('\u2705 Active! Scroll your '+label+' \u2014 counter updates above.','#1e1b4b');
 })();`
 
 const BOOKMARKLET_HREF = `javascript:${encodeURIComponent(BOOKMARKLET_SCRIPT)}`
 
 const CONSOLE_SCRIPT = `(async function() {
   if (!location.hostname.includes('twitter.com') && !location.hostname.includes('x.com')) {
-    alert('Run this on x.com/i/bookmarks'); return;
+    alert('Run this on x.com/i/bookmarks or x.com/username/likes'); return;
   }
+  const isLikes = location.pathname.includes('/likes');
+  const source = isLikes ? 'like' : 'bookmark';
+  const label = isLikes ? 'likes' : 'bookmarks';
   const all = [], seen = new Set();
   function addTweet(t) {
     if (!t?.rest_id || seen.has(t.rest_id)) return;
@@ -229,7 +239,7 @@ const CONSOLE_SCRIPT = `(async function() {
       hashtags: (leg.entities?.hashtags ?? []).map(h => h.text),
       urls: (leg.entities?.urls ?? []).map(u => u.expanded_url).filter(Boolean)
     });
-    btn.textContent = \`Export \${all.length} bookmarks →\`;
+    btn.textContent = \`Export \${all.length} \${label} →\`;
   }
   function processEntry(e) {
     if (!e) return;
@@ -243,11 +253,15 @@ const CONSOLE_SCRIPT = `(async function() {
     }
     if (e.content?.items) e.content.items.forEach(i => processEntry({ content: i.item ?? i }));
   }
+  function findInstructions(obj, depth = 0) {
+    if (!obj || typeof obj !== 'object' || depth > 6) return null;
+    if (Array.isArray(obj)) return null;
+    if (Array.isArray(obj.instructions)) return obj.instructions;
+    for (const k of Object.keys(obj)) { const r = findInstructions(obj[k], depth + 1); if (r) return r; }
+    return null;
+  }
   function processData(d) {
-    const instr =
-      d?.data?.bookmark_timeline_v2?.timeline?.instructions ??
-      d?.data?.bookmarks_timeline?.timeline?.instructions ??
-      d?.data?.timeline_by_id?.timeline?.instructions ?? [];
+    const instr = findInstructions(d) ?? [];
     instr.forEach(i => {
       (i.entries ?? []).forEach(processEntry);
       (i.moduleItems ?? []).forEach(processEntry);
@@ -268,13 +282,13 @@ const CONSOLE_SCRIPT = `(async function() {
     XMLHttpRequest.prototype.open = origOpen;
     XMLHttpRequest.prototype.send = origSend;
     [btn, autoBtn].forEach(el => { try { document.body.removeChild(el); } catch(e) {} });
-    if (!all.length) { alert('No bookmarks captured. Use Auto-scroll or scroll manually first.'); return; }
-    const blob = new Blob([JSON.stringify({ bookmarks: all }, null, 2)], { type: 'application/json' });
+    if (!all.length) { alert(\`No \${label} captured. Use Auto-scroll or scroll manually first.\`); return; }
+    const blob = new Blob([JSON.stringify({ bookmarks: all, source }, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = url; a.download = 'bookmarks.json'; a.click();
+    a.href = url; a.download = \`\${source}s.json\`; a.click();
     setTimeout(() => URL.revokeObjectURL(url), 1000);
-    console.log(\`✅ Downloaded \${all.length} bookmarks!\`);
+    console.log(\`✅ Downloaded \${all.length} \${label}!\`);
   }
   btn.onclick = doExport;
   const autoBtn = document.createElement('button');
@@ -304,7 +318,7 @@ const CONSOLE_SCRIPT = `(async function() {
             autoScrolling = false;
             autoBtn.textContent = \`✅ Done — \${all.length} captured\`;
             autoBtn.style.cssText += ';background:#14532d;color:#86efac;border:1px solid #166534';
-            console.log(\`✅ Auto-scroll complete! \${all.length} bookmarks ready. Click Export.\`);
+            console.log(\`✅ Auto-scroll complete! \${all.length} \${label} ready. Click Export.\`);
             return;
           }
           stagnant = 0;
@@ -328,7 +342,7 @@ const CONSOLE_SCRIPT = `(async function() {
     const r = await origFetch.apply(this, args);
     try {
       const u = args[0] instanceof Request ? args[0].url : String(args[0]);
-      if (u.toLowerCase().includes('bookmark')) {
+      if (u.includes('/graphql/')) {
         const d = await r.clone().json();
         processData(d);
       }
@@ -344,14 +358,14 @@ const CONSOLE_SCRIPT = `(async function() {
   };
   XMLHttpRequest.prototype.send = function(...args) {
     const xhr = this, u = xhrUrls.get(xhr) ?? '';
-    if (u.toLowerCase().includes('bookmark')) {
+    if (u.includes('/graphql/')) {
       xhr.addEventListener('load', function() {
         try { processData(JSON.parse(xhr.responseText)); } catch(e) {}
       });
     }
     return origSend.apply(this, args);
   };
-  console.log('✅ Script active. Scroll through your bookmarks, then click the purple button.');
+  console.log(\`✅ Script active. Scroll through your \${label}, then click the purple button.\`);
 })();`
 
 // ── Draggable bookmarklet link ────────────────────────────────────────────────
@@ -452,14 +466,17 @@ function UploadZone({ onFile }: { onFile: (file: File) => void }) {
       }`}
     >
       <Upload size={28} className="mx-auto mb-3 text-zinc-500" />
-      <p className="text-zinc-300 font-medium text-sm">Drop your bookmarks.json file here</p>
+      <p className="text-zinc-300 font-medium text-sm">Drop your JSON file here</p>
       <p className="text-zinc-600 text-xs mt-1">or click to browse</p>
       <input ref={inputRef} type="file" accept=".json" className="hidden" onChange={handleFileChange} />
     </div>
   )
 }
 
-function BookmarkletTab({ onFile }: { onFile: (file: File) => void }) {
+function BookmarkletTab({ onFile, importSource }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like' }) {
+  const targetUrl = importSource === 'like' ? 'https://x.com' : 'https://x.com/i/bookmarks'
+  const targetLabel = importSource === 'like' ? 'x.com/YourUsername/likes' : 'x.com/i/bookmarks'
+  const sourceLabel = importSource === 'like' ? 'likes' : 'bookmarks'
   const steps = [
     {
       num: 1,
@@ -499,12 +516,12 @@ function BookmarkletTab({ onFile }: { onFile: (file: File) => void }) {
         <span>
           Go to{' '}
           <a
-            href="https://x.com/i/bookmarks"
+            href={targetUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-indigo-400 hover:underline inline-flex items-center gap-1"
           >
-            x.com/i/bookmarks <ExternalLink size={11} />
+            {targetLabel} <ExternalLink size={11} />
           </a>{' '}
           while logged in
         </span>
@@ -512,7 +529,7 @@ function BookmarkletTab({ onFile }: { onFile: (file: File) => void }) {
     },
     {
       num: 3,
-      title: 'Click "Export X Bookmarks" in your bookmark bar',
+      title: `Click "Export X Bookmarks" in your bookmark bar`,
       content: (
         <p className="text-xs text-zinc-500 mt-1">
           A purple Export button will appear on the page
@@ -530,10 +547,10 @@ function BookmarkletTab({ onFile }: { onFile: (file: File) => void }) {
     },
     {
       num: 5,
-      title: 'Click the purple "Export N bookmarks" button',
+      title: `Click the purple "Export N ${sourceLabel}" button`,
       content: (
         <p className="text-xs text-zinc-500 mt-1">
-          A <code className="text-xs bg-zinc-800 px-1 py-0.5 rounded">bookmarks.json</code> file will download automatically.
+          A <code className="text-xs bg-zinc-800 px-1 py-0.5 rounded">{sourceLabel}.json</code> file will download automatically.
           Upload it below.
         </p>
       ),
@@ -564,7 +581,10 @@ function BookmarkletTab({ onFile }: { onFile: (file: File) => void }) {
   )
 }
 
-function ConsoleTab({ onFile }: { onFile: (file: File) => void }) {
+function ConsoleTab({ onFile, importSource }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like' }) {
+  const targetUrl = importSource === 'like' ? 'https://x.com' : 'https://x.com/i/bookmarks'
+  const targetLabel = importSource === 'like' ? 'x.com/YourUsername/likes' : 'x.com/i/bookmarks'
+  const sourceLabel = importSource === 'like' ? 'likes' : 'bookmarks'
   const steps = [
     {
       num: 1,
@@ -572,12 +592,12 @@ function ConsoleTab({ onFile }: { onFile: (file: File) => void }) {
         <span>
           Go to{' '}
           <a
-            href="https://x.com/i/bookmarks"
+            href={targetUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-indigo-400 hover:underline inline-flex items-center gap-1"
           >
-            x.com/i/bookmarks <ExternalLink size={11} />
+            {targetLabel} <ExternalLink size={11} />
           </a>{' '}
           while logged in
         </span>
@@ -613,10 +633,10 @@ function ConsoleTab({ onFile }: { onFile: (file: File) => void }) {
     },
     {
       num: 4,
-      title: 'Press Enter, then scroll through all your bookmarks',
+      title: `Press Enter, then scroll through all your ${sourceLabel}`,
       content: (
         <p className="text-xs text-zinc-500 mt-1">
-          A purple button will appear. Scroll slowly to capture all bookmarks, then click the button to download.
+          A purple button will appear. Scroll slowly to capture all {sourceLabel}, then click the button to download.
         </p>
       ),
     },
@@ -646,7 +666,7 @@ function ConsoleTab({ onFile }: { onFile: (file: File) => void }) {
   )
 }
 
-function InstructionsStep({ onFile }: { onFile: (file: File) => void }) {
+function InstructionsStep({ onFile, importSource }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like' }) {
   const [method, setMethod] = useState<Method>('bookmarklet')
 
   return (
@@ -677,9 +697,9 @@ function InstructionsStep({ onFile }: { onFile: (file: File) => void }) {
       </div>
 
       {method === 'bookmarklet' ? (
-        <BookmarkletTab onFile={onFile} />
+        <BookmarkletTab onFile={onFile} importSource={importSource} />
       ) : (
-        <ConsoleTab onFile={onFile} />
+        <ConsoleTab onFile={onFile} importSource={importSource} />
       )}
     </div>
   )
@@ -982,6 +1002,7 @@ function UncategorizedBanner({ onCategorize }: { onCategorize: () => void }) {
 
 export default function ImportPage() {
   const [step, setStep] = useState<Step>(1)
+  const [importSource, setImportSource] = useState<'bookmark' | 'like'>('bookmark')
   const [importResult, setImportResult] = useState<ImportResult | null>(null)
   const [importing, setImporting] = useState(false)
 
@@ -1002,6 +1023,7 @@ export default function ImportPage() {
     try {
       const formData = new FormData()
       formData.append('file', file)
+      formData.append('source', importSource)
 
       const res = await fetch('/api/import', { method: 'POST', body: formData })
       const data = await res.json()
@@ -1028,16 +1050,42 @@ export default function ImportPage() {
   return (
     <div className="p-8 max-w-2xl mx-auto">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-zinc-100">Import Bookmarks</h1>
-        <p className="text-zinc-400 mt-1">Export your X/Twitter bookmarks as JSON, then upload below.</p>
+        <h1 className="text-2xl font-bold text-zinc-100">Import {importSource === 'like' ? 'Likes' : 'Bookmarks'}</h1>
+        <p className="text-zinc-400 mt-1">Export your X/Twitter {importSource === 'like' ? 'likes' : 'bookmarks'} as JSON, then upload below.</p>
       </div>
+
+      {/* Source selector */}
+      {step === 1 && (
+        <div className="flex gap-2 mb-6">
+          <button
+            onClick={() => setImportSource('bookmark')}
+            className={`flex-1 px-4 py-2.5 rounded-xl text-sm font-medium transition-all border ${
+              importSource === 'bookmark'
+                ? 'bg-indigo-600 border-indigo-500 text-white'
+                : 'bg-zinc-900 border-zinc-800 text-zinc-500 hover:text-zinc-300 hover:border-zinc-700'
+            }`}
+          >
+            Bookmarks
+          </button>
+          <button
+            onClick={() => setImportSource('like')}
+            className={`flex-1 px-4 py-2.5 rounded-xl text-sm font-medium transition-all border ${
+              importSource === 'like'
+                ? 'bg-pink-600 border-pink-500 text-white'
+                : 'bg-zinc-900 border-zinc-800 text-zinc-500 hover:text-zinc-300 hover:border-zinc-700'
+            }`}
+          >
+            Likes
+          </button>
+        </div>
+      )}
 
       {step === 1 && <UncategorizedBanner onCategorize={() => setStep(3)} />}
 
       <StepIndicator current={step} />
 
       <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-6">
-        {step === 1 && <InstructionsStep onFile={handleFile} />}
+        {step === 1 && <InstructionsStep onFile={handleFile} importSource={importSource} />}
         {step === 2 && (
           <ImportingStep
             result={importing ? null : importResult}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,13 +33,15 @@ async function queryDashboard() {
     prisma.bookmark.count({ where: { categories: { none: {} } } }),
     prisma.bookmark.findMany(RECENT_QUERY),
     prisma.category.findMany(TOP_CATS_QUERY),
+    prisma.bookmark.count({ where: { source: 'bookmark' } }),
+    prisma.bookmark.count({ where: { source: 'like' } }),
   ])
 }
 
 type QueryResult = Awaited<ReturnType<typeof queryDashboard>>
 
 function buildDashboardData(result: QueryResult) {
-  const [totalBookmarks, totalCategories, totalMedia, uncategorizedCount, recentRaw, catsRaw] = result
+  const [totalBookmarks, totalCategories, totalMedia, uncategorizedCount, recentRaw, catsRaw, bookmarkSourceCount, likeSourceCount] = result
 
   const recentBookmarks: BookmarkWithMedia[] = recentRaw.map((b) => ({
     id: b.id,
@@ -61,6 +63,8 @@ function buildDashboardData(result: QueryResult) {
 
   return {
     totalBookmarks,
+    bookmarkSourceCount,
+    likeSourceCount,
     totalCategories,
     totalMedia,
     uncategorizedCount,
@@ -76,6 +80,8 @@ function buildDashboardData(result: QueryResult) {
 
 const EMPTY_DASHBOARD = {
   totalBookmarks: 0,
+  bookmarkSourceCount: 0,
+  likeSourceCount: 0,
   totalCategories: 0,
   totalMedia: 0,
   uncategorizedCount: 0,
@@ -166,7 +172,12 @@ export default async function DashboardPage() {
             <p className="text-zinc-400 mt-1.5">
               You have{' '}
               <span className="text-zinc-100 font-semibold">{data.totalBookmarks.toLocaleString()}</span>{' '}
-              bookmarks saved and ready to explore.
+              tweets saved and ready to explore.
+              {data.likeSourceCount > 0 && (
+                <span className="text-zinc-500">
+                  {' '}({data.bookmarkSourceCount.toLocaleString()} bookmarks, {data.likeSourceCount.toLocaleString()} likes)
+                </span>
+              )}
             </p>
           </div>
           {/* Quick Actions */}
@@ -199,7 +210,7 @@ export default async function DashboardPage() {
       {/* Stat Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
-          label="Total Bookmarks"
+          label={data.likeSourceCount > 0 ? `${data.bookmarkSourceCount.toLocaleString()} bookmarks · ${data.likeSourceCount.toLocaleString()} likes` : 'Total Bookmarks'}
           value={data.totalBookmarks}
           icon={BookmarkIcon}
           iconColor="text-indigo-400"

--- a/lib/exporter.ts
+++ b/lib/exporter.ts
@@ -7,6 +7,7 @@ interface BookmarkRow {
   text: string
   authorHandle: string
   authorName: string
+  source: string
   tweetCreatedAt: Date | null
   importedAt: Date
   mediaItems: MediaItemRow[]
@@ -149,6 +150,7 @@ export async function exportAllBookmarksCsv(): Promise<string> {
     'tweetId',
     'text',
     'authorHandle',
+    'source',
     'categories',
     'tweetCreatedAt',
     'mediaUrls',
@@ -163,6 +165,7 @@ export async function exportAllBookmarksCsv(): Promise<string> {
       bookmark.tweetId,
       bookmark.text,
       bookmark.authorHandle,
+      bookmark.source,
       categories,
       dateStr,
       mediaUrls,
@@ -184,6 +187,7 @@ export async function exportBookmarksJson(bookmarkIds?: string[]): Promise<strin
     text: bookmark.text,
     authorHandle: bookmark.authorHandle,
     authorName: bookmark.authorName,
+    source: bookmark.source,
     tweetCreatedAt: bookmark.tweetCreatedAt?.toISOString() ?? null,
     importedAt: bookmark.importedAt.toISOString(),
     categories: bookmark.categories.map((c) => ({

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,12 +20,14 @@ model Bookmark {
   entities        String?   // JSON: {hashtags[], urls[], mentions[], tools[], tweetType}
   enrichedAt      DateTime? // when AI enrichment last ran — drives incremental processing
   enrichmentMeta  String?   // JSON: {sentiment, people[], companies[]} from batch enrichment
+  source          String    @default("bookmark")  // "bookmark" | "like"
   mediaItems    MediaItem[]
   categories    BookmarkCategory[]
 
   @@index([authorHandle])
   @@index([tweetCreatedAt])
   @@index([enrichedAt])
+  @@index([source])
 }
 
 model Category {


### PR DESCRIPTION
## Summary
- Add a `source` field ("bookmark" | "like") to the Bookmark model to distinguish bookmarks from liked tweets
- Support importing Twitter/X likes via the GraphQL API (requires userId) and via the bookmarklet (auto-detects `/likes` URL)
- Add source filter dropdown on the bookmarks page and show bookmark/like counts on the dashboard
- Include source in CSV and JSON exports

## Changes
- `prisma/schema.prisma` — new `source` column with default `"bookmark"` and index
- `app/api/import/twitter/route.ts` — Likes GraphQL endpoint support
- `app/api/import/bookmarklet/route.ts` & `app/api/import/route.ts` — pass source through
- `app/import/page.tsx` — bookmarklet detects likes page, generic instruction parsing
- `app/bookmarks/page.tsx` — source filter (Bookmarks / Likes)
- `app/page.tsx` & `app/api/stats/route.ts` — bookmark vs like counts
- `lib/exporter.ts` — include source in exports

## Test plan
- [ ] Import bookmarks via Twitter API — verify `source` is `"bookmark"`
- [ ] Import likes via Twitter API with userId — verify `source` is `"like"`
- [ ] Use bookmarklet on `/likes` page — verify exported JSON has `source: "like"`
- [ ] Upload exported JSON file — verify source is preserved
- [ ] Filter bookmarks page by source — verify correct filtering
- [ ] Check dashboard shows correct bookmark/like counts
- [ ] Export to CSV/JSON — verify source column is included