### PR TITLE
feat(cli): add siftly CLI for AI agent access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,20 @@ ANTHROPIC_API_KEY=sk-ant-...              # optional if Claude CLI is signed in
 ANTHROPIC_BASE_URL=http://localhost:8080  # optional — for local proxies
 ```
 
+## CLI for AI Agents
+
+`cli/siftly.ts` provides direct database access without the Next.js server. Outputs JSON (pretty-printed on TTY, compact when piped). Must run from project root.
+
+```bash
+npx tsx cli/siftly.ts stats                          # Library statistics
+npx tsx cli/siftly.ts categories                     # Categories with counts
+npx tsx cli/siftly.ts search "AI agents"             # FTS5 keyword search
+npx tsx cli/siftly.ts list --limit 5                 # Recent bookmarks
+npx tsx cli/siftly.ts list --source like --category ai-resources --sort oldest
+npx tsx cli/siftly.ts show <id|tweetId>              # Full bookmark detail
+npm run siftly -- stats                              # Alternative via npm script
+```
+
 ## Common Tasks
 
 ### Run the AI pipeline manually

--- a/app/api/search/ai/route.ts
+++ b/app/api/search/ai/route.ts
@@ -3,6 +3,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import prisma from '@/lib/db'
 import { ftsSearch } from '@/lib/fts'
 import { createCliAnthropicClient } from '@/lib/claude-cli-auth'
+import { extractKeywords } from '@/lib/search-utils'
 
 // ─── Cache ────────────────────────────────────────────────────────────────────
 interface CacheEntry { results: unknown; expiresAt: number }
@@ -60,24 +61,6 @@ async function getAllCategories() {
   _categoriesCache = await prisma.category.findMany({ select: { slug: true, name: true, description: true } })
   _categoriesCacheExpiry = Date.now() + 2 * 60 * 1000
   return _categoriesCache
-}
-
-/** Extract meaningful keywords — keeps short important terms like "KYC", "AI" */
-function extractKeywords(query: string): string[] {
-  const stopWords = new Set([
-    'a', 'an', 'the', 'and', 'or', 'for', 'in', 'on', 'at', 'to', 'of',
-    'is', 'it', 'about', 'that', 'with', 'by', 'this', 'my', 'me', 'i',
-    'something', 'anything', 'some', 'any', 'show', 'find', 'get', 'use',
-    'regarding', 'context', 'would', 'could', 'should', 'want', 'need',
-    'looking', 'related', 'using', 'used', 'based',
-  ])
-  return query
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
-    .split(/\s+/)
-    // Allow short words (2+ chars) so "AI", "ML", "KYC" survive
-    .filter((w) => w.length >= 2 && !stopWords.has(w))
-    .slice(0, 10)
 }
 
 /**

--- a/cli/siftly.ts
+++ b/cli/siftly.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env npx tsx
+import prisma from '@/lib/db'
+import { ftsSearch } from '@/lib/fts'
+import { extractKeywords } from '@/lib/search-utils'
+
+// ─── Output ──────────────────────────────────────────────────────────────────
+
+const isTTY = process.stdout.isTTY
+function output(data: unknown): void {
+  const json = isTTY ? JSON.stringify(data, null, 2) : JSON.stringify(data)
+  process.stdout.write(json + '\n')
+}
+
+function die(message: string): never {
+  output({ error: message })
+  process.exit(1)
+}
+
+// ─── Arg parsing ─────────────────────────────────────────────────────────────
+
+function parseArgs(args: string[]): { positional: string[]; flags: Record<string, string> } {
+  const positional: string[] = []
+  const flags: Record<string, string> = {}
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2)
+      const next = args[i + 1]
+      if (next && !next.startsWith('--')) {
+        flags[key] = next
+        i++
+      } else {
+        flags[key] = 'true'
+      }
+    } else {
+      positional.push(arg)
+    }
+  }
+  return { positional, flags }
+}
+
+// ─── Commands ────────────────────────────────────────────────────────────────
+
+async function cmdSearch(args: string[]) {
+  const { positional, flags } = parseArgs(args)
+  const query = positional.join(' ')
+  if (!query) die('Usage: siftly search <query>')
+
+  const limit = Math.min(parseInt(flags.limit ?? '20', 10) || 20, 100)
+  const keywords = extractKeywords(query)
+  if (keywords.length === 0) die('No searchable keywords in query')
+
+  const ftsIds = await ftsSearch(keywords)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let where: any
+  if (ftsIds.length > 0) {
+    where = { id: { in: ftsIds } }
+  } else {
+    // Fallback to LIKE
+    where = {
+      OR: keywords.flatMap((kw) => [
+        { text: { contains: kw } },
+        { semanticTags: { contains: kw } },
+        { entities: { contains: kw } },
+      ]),
+    }
+  }
+
+  const bookmarks = await prisma.bookmark.findMany({
+    where,
+    take: limit,
+    orderBy: ftsIds.length > 0 ? undefined : [{ tweetCreatedAt: 'desc' }],
+    include: {
+      mediaItems: { select: { id: true, type: true, url: true } },
+      categories: {
+        include: { category: { select: { name: true, slug: true } } },
+        orderBy: { confidence: 'desc' },
+      },
+    },
+  })
+
+  output({
+    query,
+    keywords,
+    count: bookmarks.length,
+    bookmarks: bookmarks.map(formatBookmark),
+  })
+}
+
+async function cmdList(args: string[]) {
+  const { flags } = parseArgs(args)
+
+  const limit = Math.min(parseInt(flags.limit ?? '20', 10) || 20, 100)
+  const page = parseInt(flags.page ?? '1', 10) || 1
+  const skip = (page - 1) * limit
+  const sortDir = flags.sort === 'oldest' ? 'asc' as const : 'desc' as const
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const where: any = {}
+
+  if (flags.source === 'bookmark' || flags.source === 'like') {
+    where.source = flags.source
+  }
+  if (flags.category) {
+    where.categories = { some: { category: { slug: flags.category } } }
+  }
+  if (flags.author) {
+    where.authorHandle = flags.author
+  }
+  if (flags.media === 'photo' || flags.media === 'video') {
+    where.mediaItems = { some: { type: flags.media } }
+  }
+
+  const [bookmarks, total] = await Promise.all([
+    prisma.bookmark.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: [{ tweetCreatedAt: sortDir }, { importedAt: sortDir }],
+      include: {
+        mediaItems: { select: { id: true, type: true, url: true } },
+        categories: {
+          include: { category: { select: { name: true, slug: true } } },
+          orderBy: { confidence: 'desc' },
+        },
+      },
+    }),
+    prisma.bookmark.count({ where }),
+  ])
+
+  output({
+    total,
+    page,
+    limit,
+    pages: Math.ceil(total / limit),
+    bookmarks: bookmarks.map(formatBookmark),
+  })
+}
+
+async function cmdShow(args: string[]) {
+  const id = args[0]
+  if (!id) die('Usage: siftly show <id|tweetId>')
+
+  const bookmark = await prisma.bookmark.findFirst({
+    where: { OR: [{ id }, { tweetId: id }] },
+    include: {
+      mediaItems: true,
+      categories: {
+        include: { category: { select: { id: true, name: true, slug: true, color: true } } },
+        orderBy: { confidence: 'desc' },
+      },
+    },
+  })
+
+  if (!bookmark) die(`Bookmark not found: ${id}`)
+
+  output({
+    id: bookmark.id,
+    tweetId: bookmark.tweetId,
+    text: bookmark.text,
+    authorHandle: bookmark.authorHandle,
+    authorName: bookmark.authorName,
+    source: bookmark.source,
+    tweetCreatedAt: bookmark.tweetCreatedAt?.toISOString() ?? null,
+    importedAt: bookmark.importedAt.toISOString(),
+    enrichedAt: bookmark.enrichedAt?.toISOString() ?? null,
+    semanticTags: safeParse(bookmark.semanticTags),
+    entities: safeParse(bookmark.entities),
+    enrichmentMeta: safeParse(bookmark.enrichmentMeta),
+    mediaItems: bookmark.mediaItems.map((m) => ({
+      id: m.id,
+      type: m.type,
+      url: m.url,
+      thumbnailUrl: m.thumbnailUrl,
+      imageTags: safeParse(m.imageTags),
+    })),
+    categories: bookmark.categories.map((bc) => ({
+      id: bc.category.id,
+      name: bc.category.name,
+      slug: bc.category.slug,
+      color: bc.category.color,
+      confidence: bc.confidence,
+    })),
+  })
+}
+
+async function cmdCategories() {
+  const categories = await prisma.category.findMany({
+    include: { _count: { select: { bookmarks: true } } },
+    orderBy: { name: 'asc' },
+  })
+
+  output({
+    count: categories.length,
+    categories: categories.map((c) => ({
+      id: c.id,
+      name: c.name,
+      slug: c.slug,
+      color: c.color,
+      bookmarkCount: c._count.bookmarks,
+    })),
+  })
+}
+
+async function cmdStats() {
+  const [totalBookmarks, totalCategories, totalMedia, sourceGroups, enrichedCount] =
+    await Promise.all([
+      prisma.bookmark.count(),
+      prisma.category.count(),
+      prisma.mediaItem.count(),
+      prisma.bookmark.groupBy({ by: ['source'], _count: true }),
+      prisma.bookmark.count({ where: { enrichedAt: { not: null } } }),
+    ])
+
+  const sources: Record<string, number> = {}
+  for (const g of sourceGroups) {
+    sources[g.source] = g._count
+  }
+
+  output({
+    totalBookmarks,
+    enrichedBookmarks: enrichedCount,
+    unenrichedBookmarks: totalBookmarks - enrichedCount,
+    totalCategories,
+    totalMediaItems: totalMedia,
+    sources,
+  })
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function safeParse(json: string | null): unknown {
+  if (!json) return null
+  try { return JSON.parse(json) } catch { return json }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatBookmark(b: any) {
+  return {
+    id: b.id,
+    tweetId: b.tweetId,
+    text: b.text,
+    authorHandle: b.authorHandle,
+    authorName: b.authorName,
+    source: b.source,
+    tweetCreatedAt: b.tweetCreatedAt?.toISOString() ?? null,
+    mediaItems: b.mediaItems.map((m: { id: string; type: string; url: string }) => ({
+      id: m.id,
+      type: m.type,
+      url: m.url,
+    })),
+    categories: b.categories.map(
+      (bc: { category: { name: string; slug: string }; confidence: number }) => ({
+        name: bc.category.name,
+        slug: bc.category.slug,
+        confidence: bc.confidence,
+      })
+    ),
+  }
+}
+
+// ─── Router ──────────────────────────────────────────────────────────────────
+
+const COMMANDS: Record<string, string> = {
+  search: 'search <query>           FTS5 keyword search',
+  list: 'list [--source] [--category] [--author] [--media] [--sort] [--limit] [--page]',
+  show: 'show <id|tweetId>         Full bookmark detail',
+  categories: 'categories                List categories with counts',
+  stats: 'stats                     Library statistics',
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const command = args[0]
+  const rest = args.slice(1)
+
+  if (!command || command === '--help' || command === '-h') {
+    output({
+      usage: 'siftly <command> [options]',
+      commands: COMMANDS,
+    })
+    process.exit(0)
+  }
+
+  try {
+    switch (command) {
+      case 'search':
+        await cmdSearch(rest)
+        break
+      case 'list':
+        await cmdList(rest)
+        break
+      case 'show':
+        await cmdShow(rest)
+        break
+      case 'categories':
+        await cmdCategories()
+        break
+      case 'stats':
+        await cmdStats()
+        break
+      default:
+        die(`Unknown command: ${command}. Run 'siftly --help' for usage.`)
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('no such table')) {
+      die('Prisma client not generated or database not set up. Run: npx prisma generate && npx prisma db push')
+    }
+    throw err
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main()

--- a/lib/search-utils.ts
+++ b/lib/search-utils.ts
@@ -1,0 +1,17 @@
+/** Extract meaningful keywords — keeps short important terms like "KYC", "AI" */
+export function extractKeywords(query: string): string[] {
+  const stopWords = new Set([
+    'a', 'an', 'the', 'and', 'or', 'for', 'in', 'on', 'at', 'to', 'of',
+    'is', 'it', 'about', 'that', 'with', 'by', 'this', 'my', 'me', 'i',
+    'something', 'anything', 'some', 'any', 'show', 'find', 'get', 'use',
+    'regarding', 'context', 'would', 'could', 'should', 'want', 'need',
+    'looking', 'related', 'using', 'used', 'based',
+  ])
+  return query
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    // Allow short words (2+ chars) so "AI", "ML", "KYC" survive
+    .filter((w) => w.length >= 2 && !stopWords.has(w))
+    .slice(0, 10)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bookmarkx",
+  "name": "siftly",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bookmarkx",
+      "name": "siftly",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
@@ -40,6 +40,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5"
       }
     },
@@ -416,6 +417,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4704,6 +5147,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5389,6 +5874,21 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -8802,6 +9302,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "siftly": "tsx cli/siftly.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
@@ -41,6 +42,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary

- Add `cli/siftly.ts` — single-file CLI that queries the bookmark database directly (no server needed), outputting JSON for terminal AI agents
- **Commands**: `search`, `list`, `show`, `categories`, `stats` with filtering, pagination, and FTS5 search
- Extract `extractKeywords()` into shared `lib/search-utils.ts` (used by both CLI and search API route)
- Add `tsx` devDependency and `npm run siftly` script
- Document CLI usage in CLAUDE.md

## Test plan

- [ ] `npx tsx cli/siftly.ts stats` — returns library statistics JSON
- [ ] `npx tsx cli/siftly.ts categories` — lists categories with bookmark counts
- [ ] `npx tsx cli/siftly.ts search "AI agents"` — FTS5 search returns ranked results
- [ ] `npx tsx cli/siftly.ts list --source like --limit 5` — filtered listing
- [ ] `npx tsx cli/siftly.ts show <id>` — full bookmark detail with parsed JSON fields
- [ ] `npx tsx cli/siftly.ts stats | jq .` — output is valid JSON when piped
- [ ] `npx tsc --noEmit` — type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)