### PR TITLE
fix: add missing source column migration for fresh installs

### DIFF
--- a/prisma/migrations/20260308000000_add_source_column/migration.sql
+++ b/prisma/migrations/20260308000000_add_source_column/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add source column missing from init migration
+ALTER TABLE "Bookmark" ADD COLUMN "source" TEXT NOT NULL DEFAULT 'bookmark';
+
+-- CreateIndex
+CREATE INDEX "Bookmark_source_idx" ON "Bookmark"("source");

--- a/start.sh
+++ b/start.sh
@@ -43,6 +43,9 @@ fi
 if [ ! -f "prisma/dev.db" ]; then
   echo "  Setting up database..."
   npx prisma migrate deploy 2>/dev/null || npx prisma db push
+else
+  # Ensure migrations are up-to-date on existing databases
+  npx prisma migrate deploy 2>/dev/null || true
 fi
 echo ""
 


### PR DESCRIPTION
Closes #10

## Summary

- **New migration** (`20260308000000_add_source_column`) adds the `source` column and index that were missing from the init migration, fixing all bookmark imports on fresh installs
- **`start.sh`** now runs `prisma migrate deploy` on existing databases too, so current users get the fix automatically on next launch

## What was broken

The `source` field was added to `schema.prisma` after the init migration was created. Fresh installs got a database without the column, causing every `prisma.bookmark.create()` to fail silently — imports returned `{"imported": 0, "skipped": 0}` with no error in the UI.

## Test plan

- [x] Type check passes (`npx tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] Fresh install: both migrations apply, `source` column + index created
- [x] Existing DB upgrade: only the new migration applies, column added correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)