### PR TITLE
fix(import): support X article content_state blocks fallback

### DIFF
--- a/app/api/import/twitter/route.ts
+++ b/app/api/import/twitter/route.ts
@@ -80,11 +80,18 @@ interface UserLegacy {
   name?: string
 }
 
+interface ArticleBlock {
+  text?: string
+  type?: string
+}
+
 interface ArticleResult {
   title?: string
   preview_image?: { url?: string }
   cover_media?: { media_info?: { original_img_url?: string } }
   content?: string
+  // Some X article payloads include a Draft.js-like content_state
+  content_state?: { blocks?: ArticleBlock[] }
 }
 
 interface TweetResult {
@@ -167,6 +174,15 @@ function bestVideoUrl(variants: MediaVariant[]): string | null {
   return mp4[0]?.url ?? null
 }
 
+function articleBlocksText(article: ArticleResult): string {
+  const blocks = article.content_state?.blocks ?? []
+  const texts = blocks
+    .map((b) => (b.text ?? '').trim())
+    .filter(Boolean)
+    .slice(0, 8)
+  return texts.join('\n\n')
+}
+
 function tweetFullText(tweet: TweetResult): string {
   if (tweet.note_tweet?.note_tweet_results?.result?.text) {
     return tweet.note_tweet.note_tweet_results.result.text
@@ -176,6 +192,13 @@ function tweetFullText(tweet: TweetResult): string {
     const parts: string[] = []
     if (article.title) parts.push(article.title)
     if (article.content) parts.push(article.content)
+
+    // Fallback: some X articles ship content in content_state.blocks
+    if (parts.length === 0) {
+      const blocks = articleBlocksText(article)
+      if (blocks) parts.push(blocks)
+    }
+
     if (parts.length > 0) return parts.join('\n\n')
   }
   return tweet.legacy?.full_text ?? ''


### PR DESCRIPTION
Some X article payloads provide content via a Draft.js-like field named content_state.blocks (instead of a plain content string).

This PR adds a fallback in tweetFullText() to extract and join the first blocks when title/content are missing.