### PR TITLE
feat(import): opt-in auto-categorization after import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,7 @@ DATABASE_URL="file:./prisma/dev.db"
 # Recommended when exposing Siftly via a public URL (e.g. Cloudflare Tunnel).
 # SIFTLY_USERNAME=admin
 # SIFTLY_PASSWORD=your-passphrase-here
+
+# Optional: automatically trigger AI categorization after a successful import.
+# Set to 'true' to enable.
+# AUTO_CATEGORIZE_AFTER_IMPORT=true

--- a/app/api/import/twitter/route.ts
+++ b/app/api/import/twitter/route.ts
@@ -293,5 +293,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     )
   }
 
+  // Opt-in: trigger categorization in background after a successful import.
+  // Enable by setting AUTO_CATEGORIZE_AFTER_IMPORT=true in the environment.
+  if (imported > 0 && process.env.AUTO_CATEGORIZE_AFTER_IMPORT === 'true') {
+    void fetch('http://localhost:3000/api/categorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ force: false }),
+    }).catch(() => { /* best-effort */ })
+  }
+
   return NextResponse.json({ imported, skipped })
 }


### PR DESCRIPTION
Adds a fire-and-forget call to POST /api/categorize after a successful Twitter/X import.

Controlled by an environment variable so users can opt in:

AUTO_CATEGORIZE_AFTER_IMPORT=true

Off by default. Documented in .env.example.