### PR TITLE
Add .mailmap for consistent contributor attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Viperr <viperrcrypto@users.noreply.github.com> Layth Kal <laythkal@gmail.com>
+Viperr <viperrcrypto@users.noreply.github.com> viperr <viperr@alfadao.xyz>


### PR DESCRIPTION
## Summary
- Add .mailmap to normalize contributor names/emails across git log and shortlog

## Test plan
- [x] `git log --format="%aN"` shows consistent names

🤖 Generated with [Claude Code](https://claude.com/claude-code)