### PR TITLE
fix: port bug fixes to sync lib (HTML entities + article blocks)

### DIFF
--- a/lib/twitter-api.ts
+++ b/lib/twitter-api.ts
@@ -61,11 +61,18 @@ interface ArticleCoverMedia {
   media_info?: { original_img_url?: string }
 }
 
+interface ArticleBlock {
+  text?: string
+  type?: string
+}
+
 interface ArticleResult {
   title?: string
   preview_image?: { url?: string }
   cover_media?: ArticleCoverMedia
   content?: string
+  // Some X article payloads include a Draft.js-like content_state
+  content_state?: { blocks?: ArticleBlock[] }
 }
 
 export interface TweetResult {
@@ -184,10 +191,27 @@ export function extractMedia(tweet: TweetResult) {
   return results
 }
 
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+}
+
+function articleBlocksText(article: ArticleResult): string {
+  const blocks = article.content_state?.blocks ?? []
+  const texts = blocks
+    .map((b) => (b.text ?? '').trim())
+    .filter(Boolean)
+    .slice(0, 8)
+  return texts.join('\n\n')
+}
+
 export function tweetFullText(tweet: TweetResult): string {
-  // Prefer note tweet (long-form), then article title+content, then legacy text
   if (tweet.note_tweet?.note_tweet_results?.result?.text) {
-    return tweet.note_tweet.note_tweet_results.result.text
+    return decodeHtmlEntities(tweet.note_tweet.note_tweet_results.result.text)
   }
 
   const article = tweet.article?.article_results?.result
@@ -195,10 +219,17 @@ export function tweetFullText(tweet: TweetResult): string {
     const parts: string[] = []
     if (article.title) parts.push(article.title)
     if (article.content) parts.push(article.content)
-    if (parts.length > 0) return parts.join('\n\n')
+
+    // Fallback: some X articles ship content in content_state.blocks
+    if (parts.length === 0) {
+      const blocks = articleBlocksText(article)
+      if (blocks) parts.push(blocks)
+    }
+
+    if (parts.length > 0) return decodeHtmlEntities(parts.join('\n\n'))
   }
 
-  return tweet.legacy?.full_text ?? ''
+  return decodeHtmlEntities(tweet.legacy?.full_text ?? '')
 }
 
 // ── Import tweets to DB ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`lib/twitter-api.ts` (used by the auto-sync scheduler via `lib/x-sync.ts`) was missing two bug fixes already applied to the import route:

- **HTML entity decoding** (PR #31) — synced bookmarks showed raw `&amp;`, `&gt;`, `&quot;` instead of decoded characters
- **Article content_state.blocks fallback** (PR #22) — X articles using Draft.js format came through with empty text

This brings the sync lib to parity with the import route.

## Verification
- `npx tsc --noEmit` — clean
- `npx next build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)