### PR TITLE
feat: OpenAI/Codex CLI support, import parser fix, article previews

### DIFF
--- a/app/api/analyze/images/route.ts
+++ b/app/api/analyze/images/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import Anthropic from '@anthropic-ai/sdk'
 import prisma from '@/lib/db'
 import { analyzeBatch } from '@/lib/vision-analyzer'
-import { resolveAnthropicClient } from '@/lib/claude-cli-auth'
+import { AIClient, resolveAIClient } from '@/lib/ai-client'
+import { getProvider } from '@/lib/settings'
 
 // GET: returns progress stats
 export async function GET(): Promise<NextResponse> {
@@ -23,20 +23,22 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // use default
   }
 
-  const setting = await prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } })
+  const provider = await getProvider()
+  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const setting = await prisma.setting.findUnique({ where: { key: keyName } })
   const dbKey = setting?.value?.trim()
 
-  let client
+  let client: AIClient | null = null
   try {
-    client = resolveAnthropicClient({ dbKey })
+    client = await resolveAIClient({ dbKey })
   } catch {
-    return NextResponse.json({ error: 'No API key configured. Add your key in Settings or sign in to Claude CLI.' }, { status: 400 })
+    // SDK not available — will use CLI path for vision
   }
 
   return runAnalysis(client, batchSize)
 }
 
-async function runAnalysis(client: Anthropic, batchSize: number): Promise<NextResponse> {
+async function runAnalysis(client: AIClient | null, batchSize: number): Promise<NextResponse> {
   const untagged = await prisma.mediaItem.findMany({
     where: { imageTags: null, type: { in: ['photo', 'gif'] } },
     take: batchSize,

--- a/app/api/categorize/route.ts
+++ b/app/api/categorize/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
-import Anthropic from '@anthropic-ai/sdk'
 import prisma from '@/lib/db'
-import { resolveAnthropicClient } from '@/lib/claude-cli-auth'
+import { AIClient, resolveAIClient } from '@/lib/ai-client'
+import { getActiveModel, getProvider } from '@/lib/settings'
 import {
   seedDefaultCategories,
   categorizeBatch,
@@ -10,7 +10,6 @@ import {
   BOOKMARK_SELECT,
 } from '@/lib/categorizer'
 import {
-  getAnthropicModel,
   analyzeItem,
   runWithConcurrency,
   enrichBatchSemanticTags,
@@ -92,7 +91,7 @@ export async function DELETE(): Promise<NextResponse> {
   return NextResponse.json({ stopped: true })
 }
 
-const PIPELINE_WORKERS = 20
+const PIPELINE_WORKERS = 5
 const CAT_BATCH_SIZE = 25
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -111,10 +110,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { bookmarkIds = [], apiKey, force = false } = body
 
   if (apiKey && typeof apiKey === 'string' && apiKey.trim() !== '') {
+    const currentProvider = await getProvider()
+    const keySlot = currentProvider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
     await prisma.setting.upsert({
-      where: { key: 'anthropicApiKey' },
+      where: { key: keySlot },
       update: { value: apiKey.trim() },
-      create: { key: 'anthropicApiKey', value: apiKey.trim() },
+      create: { key: keySlot, value: apiKey.trim() },
     })
   }
 
@@ -143,20 +144,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     error: null,
   })
 
+  const provider = await getProvider()
+  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
   const dbApiKey =
-    (await prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } }))?.value?.trim() || ''
+    (await prisma.setting.findUnique({ where: { key: keyName } }))?.value?.trim() || ''
 
   void (async () => {
     const counts = { visionTagged: 0, entitiesExtracted: 0, enriched: 0, categorized: 0 }
 
     try {
-      let client: Anthropic
+      let client: AIClient | null = null
       try {
-        client = resolveAnthropicClient({ dbKey: dbApiKey })
+        client = await resolveAIClient({ dbKey: dbApiKey })
       } catch {
-        setState({ lastError: 'No Anthropic API key configured. Go to Settings to add one, or log in with Claude CLI.' })
-        console.error('No API key or CLI auth — skipping pipeline')
-        return
+        // SDK client not available — CLI path may still work (e.g. ChatGPT OAuth via codex exec)
+        console.warn('No SDK client available — will rely on CLI path')
       }
 
         await seedDefaultCategories()
@@ -208,7 +210,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           const categoryDescriptions = Object.fromEntries(
             dbCategories.map((c) => [c.slug, c.description?.trim() || c.name]),
           )
-          const model = await getAnthropicModel()
+          const model = await getActiveModel()
 
           // Shared categorization queue (JS single-threaded: splice is atomic vs async)
           const catPending: string[] = []
@@ -269,7 +271,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             })
             if (!bm) return
 
-            // Vision: analyze any untagged media items
+            // Vision: analyze any untagged media items (SDK or CLI)
             let anyVisionRan = false
             for (const media of bm.mediaItems) {
               if (shouldAbort()) return

--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -126,7 +126,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   return NextResponse.json({
     jobId: importJob.id,
-    count: importedCount,
+    imported: importedCount,
     skipped: skippedCount,
+    parsed: parsedBookmarks.length,
   })
 }

--- a/app/api/link-preview/route.ts
+++ b/app/api/link-preview/route.ts
@@ -66,6 +66,69 @@ function decodeHtmlEntities(str: string): string {
     .replace(/&apos;/g, "'")
 }
 
+/** Try to fetch rich data from Twitter's syndication API (articles, cards, etc.) */
+async function fetchXArticlePreview(tweetId: string): Promise<{
+  title: string; description: string; image: string; siteName: string; domain: string; url: string
+} | null> {
+  try {
+    const res = await fetch(
+      `https://cdn.syndication.twimg.com/tweet-result?id=${tweetId}&token=x`,
+      { headers: { 'User-Agent': BROWSER_UA }, signal: AbortSignal.timeout(8000) },
+    )
+    if (!res.ok) return null
+    const data = await res.json() as {
+      article?: {
+        rest_id?: string
+        title?: string
+        preview_text?: string
+        cover_media?: { media_info?: { original_img_url?: string } }
+      }
+      card?: {
+        name?: string
+        binding_values?: Record<string, { string_value?: string; image_value?: { url?: string } }>
+      }
+      user?: { name?: string; screen_name?: string; profile_image_url_https?: string }
+    }
+
+    // X Article (native long-form posts)
+    if (data.article?.title) {
+      const articleId = data.article.rest_id || tweetId
+      return {
+        title: data.article.title,
+        description: data.article.preview_text || '',
+        image: data.article.cover_media?.media_info?.original_img_url || '',
+        siteName: data.user?.name || 'X',
+        domain: 'x.com',
+        url: `https://x.com/i/article/${articleId}`,
+      }
+    }
+
+    // Twitter Card (link previews embedded in tweets)
+    if (data.card?.binding_values) {
+      const bv = data.card.binding_values
+      const cardTitle = bv.title?.string_value
+      if (cardTitle) {
+        return {
+          title: cardTitle,
+          description: bv.description?.string_value || '',
+          image: bv.thumbnail_image_original?.image_value?.url
+            || bv.thumbnail_image?.image_value?.url
+            || bv.summary_photo_image_original?.image_value?.url
+            || bv.summary_photo_image?.image_value?.url
+            || '',
+          siteName: bv.vanity_url?.string_value || data.user?.name || 'X',
+          domain: bv.domain?.string_value || 'x.com',
+          url: bv.card_url?.string_value || bv.url?.string_value || `https://x.com/i/status/${tweetId}`,
+        }
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const url = request.nextUrl.searchParams.get('url')
   if (!url) {
@@ -75,6 +138,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   if (isPrivateUrl(url)) {
     return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
   }
+
+  // Also accept an optional tweetId param for X article enrichment
+  const rawTweetId = request.nextUrl.searchParams.get('tweetId')
+  const tweetId = rawTweetId && /^\d+$/.test(rawTweetId) ? rawTweetId : null
 
   try {
     const res = await fetch(url, {
@@ -90,6 +157,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     if (!res.ok) {
       return NextResponse.json({ error: `HTTP ${res.status}` }, { status: 502 })
+    }
+
+    // SSRF: re-check the final URL after redirects to prevent open-redirect chaining into private networks
+    if (isPrivateUrl(res.url)) {
+      return NextResponse.json({ error: 'Invalid URL' }, { status: 400 })
     }
 
     // Only read first 50KB — enough for head tags
@@ -125,6 +197,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       try { return new URL(finalUrl).hostname.replace(/^www\./, '') } catch { return '' }
     })()
 
+    const isXDomain = domain === 'x.com' || domain === 'twitter.com'
+
+    // X article pages (and many X URLs) are JS-rendered — OG scraping returns
+    // nothing useful. Try the syndication API first for any X URL when we have a tweetId.
+    if (isXDomain && tweetId) {
+      const articleData = await fetchXArticlePreview(tweetId)
+      if (articleData) {
+        return NextResponse.json(articleData, { headers: CACHE_HEADERS })
+      }
+    }
+
     const title = extractMeta(
       html,
       /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i,
@@ -153,6 +236,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       /<meta[^>]+property=["']og:site_name["'][^>]+content=["']([^"']+)["']/i,
       /<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:site_name["']/i,
     )
+
+    // If OG scrape returned poor results for an X URL, try syndication as fallback
+    if (isXDomain && tweetId && !image && (!title || /^(Article on X|View on X|post \/ X|X)$/i.test(title))) {
+      const articleData = await fetchXArticlePreview(tweetId)
+      if (articleData) {
+        return NextResponse.json(articleData, { headers: CACHE_HEADERS })
+      }
+    }
 
     const resolvedTitle = title || syntheticTitle(finalUrl, siteName)
 

--- a/app/api/search/ai/route.ts
+++ b/app/api/search/ai/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import Anthropic from '@anthropic-ai/sdk'
 import prisma from '@/lib/db'
 import { ftsSearch } from '@/lib/fts'
-import { resolveAnthropicClient } from '@/lib/claude-cli-auth'
-import { getAnthropicModel } from '@/lib/settings'
+import { AIClient, resolveAIClient } from '@/lib/ai-client'
+import { getActiveModel, getProvider } from '@/lib/settings'
 import { extractKeywords } from '@/lib/search-utils'
+import { getCliAvailability, claudePrompt, modelNameToCliAlias } from '@/lib/claude-cli-auth'
+import { getCodexCliAvailability, codexPrompt } from '@/lib/codex-cli'
 
 // ─── Cache ────────────────────────────────────────────────────────────────────
 interface CacheEntry { results: unknown; expiresAt: number }
@@ -30,7 +31,9 @@ let _categoriesCacheExpiry = 0
 
 async function getDbApiKey(): Promise<string> {
   if (_apiKey !== null && Date.now() < _apiKeyExpiry) return _apiKey
-  const setting = await prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } })
+  const provider = await getProvider()
+  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const setting = await prisma.setting.findUnique({ where: { key: keyName } })
   const fromDb = setting?.value?.trim() ?? ''
   _apiKey = fromDb
   _apiKeyExpiry = Date.now() + 60_000
@@ -196,13 +199,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const cached = getCached(cacheKey)
   if (cached) return NextResponse.json(cached)
 
-  let client: Anthropic
+  let client: AIClient | null = null
   try {
-    client = resolveAnthropicClient({ dbKey: apiKey })
+    client = await resolveAIClient({ dbKey: apiKey })
   } catch {
-    return NextResponse.json({ error: 'No Anthropic API key configured. Add it in Settings or log in with Claude CLI.' }, { status: 400 })
+    // SDK not available — will try CLI path
   }
-  const model = await getAnthropicModel()
+  const model = await getActiveModel()
+  const provider = await getProvider()
 
   const categoryFilter = category
     ? { categories: { some: { category: { slug: category } } } }
@@ -337,23 +341,53 @@ Constraints:
 - Only return ids from the list above
 - reason must be specific, not generic ("shows bitcoin price crash chart" not "related to crypto")`
 
-  let aiResponse: { queryIntent?: string; matches: { id: string; score: number; reason: string }[]; explanation: string }
+  let aiResponse: { queryIntent?: string; matches: { id: string; score: number; reason: string }[]; explanation: string } = { matches: [], explanation: 'No results found.' }
 
-  try {
-    const msg = await client.messages.create({
-      model,
-      max_tokens: 1500,
-      messages: [{ role: 'user', content: prompt }],
-    })
-    const rawText = msg.content.find((b) => b.type === 'text')?.text ?? '{}'
+  const parseSearchResponse = (rawText: string): typeof aiResponse => {
     const jsonMatch = rawText.match(/\{[\s\S]*\}/)
-    aiResponse = jsonMatch
+    return jsonMatch
       ? (JSON.parse(jsonMatch[0]) as typeof aiResponse)
       : { matches: [], explanation: 'No results found.' }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.error('AI search error:', msg)
-    return NextResponse.json({ error: `AI search failed: ${msg}` }, { status: 500 })
+  }
+
+  // Try CLI first (works with ChatGPT OAuth), then fall back to SDK
+  let cliSucceeded = false
+  if (provider === 'openai' && await getCodexCliAvailability()) {
+    try {
+      const result = await codexPrompt(prompt, { timeoutMs: 90_000 })
+      if (result.success && result.data) {
+        aiResponse = parseSearchResponse(result.data)
+        cliSucceeded = true
+      }
+    } catch { /* fall through to SDK */ }
+  } else if (provider === 'anthropic' && await getCliAvailability()) {
+    try {
+      const cliModel = modelNameToCliAlias(model)
+      const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 90_000 })
+      if (result.success && result.data) {
+        aiResponse = parseSearchResponse(result.data)
+        cliSucceeded = true
+      }
+    } catch { /* fall through to SDK */ }
+  }
+
+  if (!cliSucceeded) {
+    if (!client) {
+      return NextResponse.json({ error: 'No CLI available and no API key configured. Add an API key in Settings or install Codex/Claude CLI.' }, { status: 400 })
+    }
+    try {
+      const response = await client.createMessage({
+        model,
+        max_tokens: 1500,
+        messages: [{ role: 'user', content: prompt }],
+      })
+      const rawText = response.text ?? '{}'
+      aiResponse = parseSearchResponse(rawText)
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err)
+      console.error('AI search error:', errMsg)
+      return NextResponse.json({ error: `AI search failed: ${errMsg}` }, { status: 500 })
+    }
   }
 
   // ── Step 4: Hydrate results ────────────────────────────────────────────────

--- a/app/api/settings/cli-status/route.ts
+++ b/app/api/settings/cli-status/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from 'next/server'
+import prisma from '@/lib/db'
 import { getCliAuthStatus, getCliAvailability } from '@/lib/claude-cli-auth'
+import { getCodexCliAuthStatus } from '@/lib/openai-auth'
 
 export async function GET(): Promise<NextResponse> {
   const oauthStatus = getCliAuthStatus()
+  const codexStatus = getCodexCliAuthStatus()
+
+  // Read provider directly from DB (not cached) — this endpoint is called
+  // right after the user toggles the provider, so it must be fresh.
+  const providerSetting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
+  const provider = providerSetting?.value === 'openai' ? 'openai' : 'anthropic'
 
   // Only check CLI subprocess availability if OAuth credentials exist
-  // (avoids unnecessary subprocess spawn when CLI isn't installed)
   const cliDirectAvailable = oauthStatus.available && !oauthStatus.expired
     ? await getCliAvailability()
     : false
@@ -14,5 +21,7 @@ export async function GET(): Promise<NextResponse> {
     ...oauthStatus,
     cliDirectAvailable,
     mode: cliDirectAvailable ? 'cli' : oauthStatus.available ? 'oauth' : 'api-key',
+    codex: codexStatus,
+    provider,
   })
 }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db'
+import { invalidateSettingsCache } from '@/lib/settings'
 
 function maskKey(raw: string | null): string | null {
   if (!raw) return null
@@ -13,17 +14,37 @@ const ALLOWED_ANTHROPIC_MODELS = [
   'claude-opus-4-6',
 ] as const
 
+const ALLOWED_OPENAI_MODELS = [
+  'gpt-4.1-mini',
+  'gpt-4.1',
+  'gpt-4.1-nano',
+  'o4-mini',
+  'o3',
+] as const
+
 export async function GET(): Promise<NextResponse> {
   try {
-    const [anthropic, anthropicModel] = await Promise.all([
+    const [anthropic, anthropicModel, provider, openai, openaiModel, xClientId, xClientSecret] = await Promise.all([
       prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'anthropicModel' } }),
+      prisma.setting.findUnique({ where: { key: 'aiProvider' } }),
+      prisma.setting.findUnique({ where: { key: 'openaiApiKey' } }),
+      prisma.setting.findUnique({ where: { key: 'openaiModel' } }),
+      prisma.setting.findUnique({ where: { key: 'x_oauth_client_id' } }),
+      prisma.setting.findUnique({ where: { key: 'x_oauth_client_secret' } }),
     ])
 
     return NextResponse.json({
+      provider: provider?.value ?? 'anthropic',
       anthropicApiKey: maskKey(anthropic?.value ?? null),
       hasAnthropicKey: anthropic !== null,
       anthropicModel: anthropicModel?.value ?? 'claude-haiku-4-5-20251001',
+      openaiApiKey: maskKey(openai?.value ?? null),
+      hasOpenaiKey: openai !== null,
+      openaiModel: openaiModel?.value ?? 'gpt-4.1-mini',
+      xOAuthClientId: maskKey(xClientId?.value ?? null),
+      xOAuthClientSecret: maskKey(xClientSecret?.value ?? null),
+      hasXOAuth: !!xClientId?.value,
     })
   } catch (err) {
     console.error('Settings GET error:', err)
@@ -38,6 +59,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: {
     anthropicApiKey?: string
     anthropicModel?: string
+    provider?: string
+    openaiApiKey?: string
+    openaiModel?: string
+    xOAuthClientId?: string
+    xOAuthClientSecret?: string
   } = {}
   try {
     body = await request.json()
@@ -45,7 +71,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const { anthropicApiKey, anthropicModel } = body
+  const { anthropicApiKey, anthropicModel, provider, openaiApiKey, openaiModel } = body
+
+  // Save provider if provided
+  if (provider !== undefined) {
+    if (provider !== 'anthropic' && provider !== 'openai') {
+      return NextResponse.json({ error: 'Invalid provider' }, { status: 400 })
+    }
+    await prisma.setting.upsert({
+      where: { key: 'aiProvider' },
+      update: { value: provider },
+      create: { key: 'aiProvider', value: provider },
+    })
+    invalidateSettingsCache()
+    return NextResponse.json({ saved: true })
+  }
 
   // Save Anthropic model if provided
   if (anthropicModel !== undefined) {
@@ -57,6 +97,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       update: { value: anthropicModel },
       create: { key: 'anthropicModel', value: anthropicModel },
     })
+    invalidateSettingsCache()
+    return NextResponse.json({ saved: true })
+  }
+
+  // Save OpenAI model if provided
+  if (openaiModel !== undefined) {
+    if (!(ALLOWED_OPENAI_MODELS as readonly string[]).includes(openaiModel)) {
+      return NextResponse.json({ error: 'Invalid OpenAI model' }, { status: 400 })
+    }
+    await prisma.setting.upsert({
+      where: { key: 'openaiModel' },
+      update: { value: openaiModel },
+      create: { key: 'openaiModel', value: openaiModel },
+    })
+    invalidateSettingsCache()
     return NextResponse.json({ saved: true })
   }
 
@@ -72,12 +127,62 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         update: { value: trimmed },
         create: { key: 'anthropicApiKey', value: trimmed },
       })
+      invalidateSettingsCache()
       return NextResponse.json({ saved: true })
     } catch (err) {
       console.error('Settings POST (anthropic) error:', err)
       return NextResponse.json(
         { error: `Failed to save: ${err instanceof Error ? err.message : String(err)}` },
         { status: 500 }
+      )
+    }
+  }
+
+  // Save OpenAI key if provided
+  if (openaiApiKey !== undefined) {
+    if (typeof openaiApiKey !== 'string' || openaiApiKey.trim() === '') {
+      return NextResponse.json({ error: 'Invalid openaiApiKey value' }, { status: 400 })
+    }
+    const trimmed = openaiApiKey.trim()
+    try {
+      await prisma.setting.upsert({
+        where: { key: 'openaiApiKey' },
+        update: { value: trimmed },
+        create: { key: 'openaiApiKey', value: trimmed },
+      })
+      invalidateSettingsCache()
+      return NextResponse.json({ saved: true })
+    } catch (err) {
+      console.error('Settings POST (openai) error:', err)
+      return NextResponse.json(
+        { error: `Failed to save: ${err instanceof Error ? err.message : String(err)}` },
+        { status: 500 }
+      )
+    }
+  }
+
+  // Save X OAuth credentials if provided
+  const { xOAuthClientId, xOAuthClientSecret } = body
+  const xKeys: { key: string; value: string | undefined }[] = [
+    { key: 'x_oauth_client_id', value: xOAuthClientId },
+    { key: 'x_oauth_client_secret', value: xOAuthClientSecret },
+  ]
+  const xToSave = xKeys.filter((k) => k.value !== undefined && k.value.trim() !== '')
+  if (xToSave.length > 0) {
+    try {
+      for (const { key, value } of xToSave) {
+        await prisma.setting.upsert({
+          where: { key },
+          update: { value: value!.trim() },
+          create: { key, value: value!.trim() },
+        })
+      }
+      return NextResponse.json({ saved: true })
+    } catch (err) {
+      console.error('Settings POST (X OAuth) error:', err)
+      return NextResponse.json(
+        { error: `Failed to save: ${err instanceof Error ? err.message : String(err)}` },
+        { status: 500 },
       )
     }
   }
@@ -93,11 +198,12 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const allowed = ['anthropicApiKey']
+  const allowed = ['anthropicApiKey', 'openaiApiKey', 'x_oauth_client_id', 'x_oauth_client_secret']
   if (!body.key || !allowed.includes(body.key)) {
     return NextResponse.json({ error: 'Invalid key' }, { status: 400 })
   }
 
   await prisma.setting.deleteMany({ where: { key: body.key } })
+  invalidateSettingsCache()
   return NextResponse.json({ deleted: true })
 }

--- a/app/api/settings/test/route.ts
+++ b/app/api/settings/test/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db'
 import { resolveAnthropicClient, getCliAuthStatus } from '@/lib/claude-cli-auth'
+import { resolveOpenAIClient } from '@/lib/openai-auth'
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: { provider?: string } = {}
@@ -21,7 +22,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
       client = resolveAnthropicClient({ dbKey })
     } catch {
-      // Check if CLI auth is available but expired
       const cliStatus = getCliAuthStatus()
       if (cliStatus.available && cliStatus.expired) {
         return NextResponse.json({ working: false, error: 'Claude CLI session expired — run `claude` to refresh' })
@@ -32,6 +32,35 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
       await client.messages.create({
         model: 'claude-haiku-4-5-20251001',
+        max_tokens: 5,
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+      return NextResponse.json({ working: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      const friendly = msg.includes('401') || msg.includes('invalid_api_key')
+        ? 'Invalid API key'
+        : msg.includes('403')
+        ? 'Key does not have permission'
+        : msg.slice(0, 120)
+      return NextResponse.json({ working: false, error: friendly })
+    }
+  }
+
+  if (provider === 'openai') {
+    const setting = await prisma.setting.findUnique({ where: { key: 'openaiApiKey' } })
+    const dbKey = setting?.value?.trim()
+
+    let client
+    try {
+      client = resolveOpenAIClient({ dbKey })
+    } catch {
+      return NextResponse.json({ working: false, error: 'No OpenAI API key found. Add one in Settings or set up Codex CLI.' })
+    }
+
+    try {
+      await client.chat.completions.create({
+        model: 'gpt-4.1-mini',
         max_tokens: 5,
         messages: [{ role: 'user', content: 'hi' }],
       })

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react'
 import Link from 'next/link'
-import { Upload, CheckCircle, ChevronRight, Loader2, Copy, Check, ExternalLink, Sparkles, Eye, Tag, Brain, Layers, StopCircle, RefreshCw, Clock, KeyRound, Trash2 } from 'lucide-react'
+import { Upload, CheckCircle, ChevronRight, Loader2, Copy, Check, ExternalLink, Sparkles, Eye, Tag, Brain, Layers, StopCircle, RefreshCw, Clock, KeyRound, Trash2, AlertCircle, User, LogOut } from 'lucide-react'
 import * as Progress from '@radix-ui/react-progress'
 
 type Step = 1 | 2 | 3
@@ -12,6 +12,7 @@ interface ImportResult {
   imported: number
   skipped: number
   total: number
+  parsed: number
 }
 
 type Stage = 'vision' | 'entities' | 'enrichment' | 'categorize' | 'parallel' | null
@@ -666,245 +667,213 @@ function ConsoleTab({ onFile, importSource }: { onFile: (file: File) => void; im
   )
 }
 
-// ── Live Import Tab ───────────────────────────────────────────────────────────
+// ── Live Import Tab (OAuth 2.0 PKCE) ─────────────────────────────────────────
 
-interface LiveConfig {
-  hasCredentials: boolean
-  syncInterval: string
-  lastSync: string | null
-  schedulerRunning: boolean
-}
-
-const INTERVAL_LABELS: Record<string, string> = {
-  off: 'Off',
-  '1h': 'Every hour',
-  '4h': 'Every 4 hours',
-  '8h': 'Every 8 hours',
-  '24h': 'Every 24 hours',
+interface OAuthStatus {
+  configured: boolean
+  connected: boolean
+  tokenExpired?: boolean
+  user?: { id?: string; name?: string; username?: string } | null
+  error?: string
 }
 
 function LiveImportTab({ onSynced }: { onSynced: (result: ImportResult) => void }) {
-  const [authToken, setAuthToken] = useState('')
-  const [ct0, setCt0] = useState('')
-  const [config, setConfig] = useState<LiveConfig | null>(null)
-  const [saving, setSaving] = useState(false)
+  const [status, setStatus] = useState<OAuthStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [connecting, setConnecting] = useState(false)
   const [syncing, setSyncing] = useState(false)
-  const [interval, setInterval_] = useState('off')
+  const [disconnecting, setDisconnecting] = useState(false)
   const [error, setError] = useState('')
 
+  // Check for OAuth callback params in URL
   useEffect(() => {
-    fetch('/api/import/live')
-      .then(async (r) => {
-        if (!r.ok) {
-          setError('Failed to load sync configuration')
-          return
-        }
-        const data: LiveConfig = await r.json()
-        setConfig(data)
-        setInterval_(data.syncInterval)
-      })
-      .catch(() => {
-        setError('Could not connect to the server')
-      })
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('x_connected') === 'true') {
+      // Clean URL
+      window.history.replaceState({}, '', window.location.pathname)
+    }
+    if (params.get('x_error')) {
+      setError(`OAuth error: ${params.get('x_error')}`)
+      window.history.replaceState({}, '', window.location.pathname)
+    }
   }, [])
 
-  async function handleSaveCredentials() {
-    if (!authToken.trim() || !ct0.trim()) {
-      setError('Both auth_token and ct0 are required')
-      return
-    }
-    setError('')
-    setSaving(true)
-    try {
-      const res = await fetch('/api/import/live', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ authToken: authToken.trim(), ct0: ct0.trim() }),
+  // Fetch status on mount
+  useEffect(() => {
+    fetch('/api/import/x-oauth/status')
+      .then(async (r) => {
+        if (!r.ok) throw new Error('Failed to check status')
+        const data: OAuthStatus = await r.json()
+        setStatus(data)
       })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.error ?? 'Failed to save')
-      }
-      setConfig((c) => c
-        ? { ...c, hasCredentials: true }
-        : { hasCredentials: true, syncInterval: 'off', lastSync: null, schedulerRunning: false },
-      )
-      setAuthToken('')
-      setCt0('')
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save')
-    } finally {
-      setSaving(false)
-    }
-  }
+      .catch(() => setError('Could not connect to the server'))
+      .finally(() => setLoading(false))
+  }, [])
 
-  async function handleDeleteCredentials() {
+  async function handleConnect() {
+    setError('')
+    setConnecting(true)
     try {
-      const res = await fetch('/api/import/live', { method: 'DELETE' })
-      if (!res.ok) throw new Error('Failed to remove credentials')
-      setConfig((c) => c ? { ...c, hasCredentials: false, lastSync: null, schedulerRunning: false, syncInterval: 'off' } : c)
-      setInterval_('off')
+      const res = await fetch('/api/import/x-oauth/authorize')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Failed to start OAuth')
+      window.location.href = data.authUrl
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to remove credentials')
+      setError(err instanceof Error ? err.message : 'Failed to connect')
+      setConnecting(false)
     }
   }
 
-  async function handleSync() {
+  async function handleDisconnect() {
+    setError('')
+    setDisconnecting(true)
+    try {
+      const res = await fetch('/api/import/x-oauth/disconnect', { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to disconnect')
+      setStatus({ configured: true, connected: false })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect')
+    } finally {
+      setDisconnecting(false)
+    }
+  }
+
+  async function handleFetchBookmarks() {
     setError('')
     setSyncing(true)
     try {
-      const res = await fetch('/api/import/live/sync', { method: 'POST' })
-      const data = await res.json().catch(() => ({}))
-      if (!res.ok) throw new Error(data.error ?? 'Sync failed')
-      const imported = data.imported ?? 0
-      const skipped = data.skipped ?? 0
-      onSynced({ imported, skipped, total: imported + skipped })
+      const res = await fetch('/api/import/x-oauth/fetch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ maxPages: 10 }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Fetch failed')
+      onSynced({
+        imported: data.imported ?? 0,
+        skipped: data.skipped ?? 0,
+        total: data.total ?? 0,
+        parsed: data.total ?? 0,
+      })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Sync failed')
+      setError(err instanceof Error ? err.message : 'Fetch failed')
     } finally {
       setSyncing(false)
     }
   }
 
-  async function handleIntervalChange(newInterval: string) {
-    const previousInterval = interval
-    setInterval_(newInterval)
-    try {
-      const res = await fetch('/api/import/live', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ syncInterval: newInterval }),
-      })
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}))
-        throw new Error(data.error ?? 'Failed to update sync schedule')
-      }
-      setConfig((c) => c ? { ...c, syncInterval: newInterval, schedulerRunning: newInterval !== 'off' } : c)
-    } catch (err) {
-      setInterval_(previousInterval)
-      setError(err instanceof Error ? err.message : 'Failed to update sync schedule')
-    }
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 size={20} className="animate-spin text-zinc-500" />
+      </div>
+    )
   }
 
   return (
     <div className="space-y-6">
-      {/* How to get credentials */}
-      <div className="space-y-3">
-        <p className="text-sm text-zinc-300 font-medium flex items-center gap-2">
-          <KeyRound size={14} className="text-indigo-400" />
-          X Session Cookies
+      {/* Info banner */}
+      <div className="text-xs text-zinc-500 space-y-1.5 bg-zinc-800/50 border border-zinc-700/50 rounded-xl p-4">
+        <p className="text-zinc-300 font-medium text-sm mb-2 flex items-center gap-2">
+          <ExternalLink size={14} className="text-indigo-400" />
+          X OAuth 2.0 (Recommended)
         </p>
-        <div className="text-xs text-zinc-500 space-y-1.5 pl-5">
-          <p>1. Open <a href="https://x.com" target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">x.com</a> and log in</p>
-          <p>2. Open DevTools (<kbd className="bg-zinc-800 border border-zinc-700 px-1 py-0.5 rounded font-mono">F12</kbd>) &rarr; <strong className="text-zinc-400">Application</strong> tab &rarr; <strong className="text-zinc-400">Cookies</strong></p>
-          <p>3. Copy <code className="bg-zinc-800 px-1 py-0.5 rounded">auth_token</code> and <code className="bg-zinc-800 px-1 py-0.5 rounded">ct0</code></p>
-        </div>
+        <p>Connect your X account using the official OAuth 2.0 flow. This is the X-approved method — no cookies or session tokens needed.</p>
+        <p className="text-zinc-600 mt-1">Requires X OAuth Client ID in Settings. Scopes: bookmark.read, tweet.read, users.read</p>
       </div>
 
-      {/* Credential status + input */}
-      {config?.hasCredentials ? (
-        <div className="flex items-center justify-between gap-3 p-3.5 rounded-xl bg-emerald-500/8 border border-emerald-500/20">
-          <div className="flex items-center gap-2.5">
-            <CheckCircle size={15} className="text-emerald-400 shrink-0" />
-            <span className="text-sm text-emerald-300">Credentials saved</span>
-            {config.lastSync && (
-              <span className="text-xs text-zinc-500">
-                &middot; Last sync: {new Date(config.lastSync).toLocaleString()}
-              </span>
-            )}
+      {/* Not configured */}
+      {!status?.configured && (
+        <div className="flex items-center gap-3 p-3.5 rounded-xl bg-amber-500/8 border border-amber-500/20">
+          <AlertCircle size={15} className="text-amber-400 shrink-0" />
+          <div>
+            <p className="text-sm text-amber-300">X OAuth not configured</p>
+            <p className="text-xs text-zinc-500 mt-0.5">
+              Add your X OAuth Client ID (and optionally Client Secret) in{' '}
+              <Link href="/settings" className="text-indigo-400 hover:underline">Settings</Link>
+            </p>
           </div>
-          <button
-            onClick={handleDeleteCredentials}
-            className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
-            title="Remove credentials"
-          >
-            <Trash2 size={14} />
-          </button>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          <div className="space-y-2">
-            <input
-              type="password"
-              placeholder="auth_token"
-              value={authToken}
-              onChange={(e) => setAuthToken(e.target.value)}
-              className="w-full px-3 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm placeholder:text-zinc-600 focus:outline-none focus:border-indigo-500/50 font-mono"
-            />
-            <input
-              type="password"
-              placeholder="ct0"
-              value={ct0}
-              onChange={(e) => setCt0(e.target.value)}
-              className="w-full px-3 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm placeholder:text-zinc-600 focus:outline-none focus:border-indigo-500/50 font-mono"
-            />
-          </div>
-          <button
-            onClick={handleSaveCredentials}
-            disabled={saving || !authToken.trim() || !ct0.trim()}
-            className="w-full py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center justify-center gap-2"
-          >
-            {saving ? <Loader2 size={14} className="animate-spin" /> : <KeyRound size={14} />}
-            {saving ? 'Saving...' : 'Save Credentials'}
-          </button>
         </div>
       )}
 
-      {error && (
-        <p className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
-          {error}
-        </p>
+      {/* Configured but not connected */}
+      {status?.configured && !status?.connected && (
+        <button
+          onClick={handleConnect}
+          disabled={connecting}
+          className="w-full py-3 rounded-xl bg-zinc-900 hover:bg-zinc-800 border border-zinc-700 text-white font-medium transition-colors flex items-center justify-center gap-2.5"
+        >
+          {connecting ? (
+            <>
+              <Loader2 size={16} className="animate-spin" />
+              Redirecting to X...
+            </>
+          ) : (
+            <>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+              Connect X Account
+            </>
+          )}
+        </button>
       )}
 
-      {/* Sync button */}
-      {config?.hasCredentials && (
+      {/* Connected */}
+      {status?.connected && (
         <>
+          <div className="flex items-center justify-between gap-3 p-3.5 rounded-xl bg-emerald-500/8 border border-emerald-500/20">
+            <div className="flex items-center gap-2.5">
+              <CheckCircle size={15} className="text-emerald-400 shrink-0" />
+              <div>
+                <span className="text-sm text-emerald-300">Connected to X</span>
+                {status.user?.username && (
+                  <span className="text-xs text-zinc-500 ml-2">
+                    <User size={11} className="inline -mt-0.5 mr-0.5" />
+                    @{status.user.username}
+                  </span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={handleDisconnect}
+              disabled={disconnecting}
+              className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+              title="Disconnect X account"
+            >
+              {disconnecting ? <Loader2 size={14} className="animate-spin" /> : <LogOut size={14} />}
+            </button>
+          </div>
+
+          {status.tokenExpired && (
+            <div className="flex items-center gap-2 p-3 rounded-xl bg-amber-500/8 border border-amber-500/20">
+              <AlertCircle size={14} className="text-amber-400 shrink-0" />
+              <p className="text-xs text-amber-300">Token expired. Siftly will try to auto-refresh, or you can reconnect.</p>
+            </div>
+          )}
+
           <button
-            onClick={handleSync}
+            onClick={handleFetchBookmarks}
             disabled={syncing}
             className="w-full py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-60 text-white font-medium transition-colors flex items-center justify-center gap-2"
           >
             {syncing ? (
               <>
                 <Loader2 size={16} className="animate-spin" />
-                Syncing bookmarks...
+                Fetching bookmarks...
               </>
             ) : (
               <>
                 <RefreshCw size={16} />
-                Sync Now
+                Fetch Bookmarks from X
               </>
             )}
           </button>
-
-          {/* Auto-sync schedule */}
-          <div className="border-t border-zinc-800 pt-5">
-            <p className="text-xs text-zinc-500 mb-3 uppercase tracking-wider font-medium flex items-center gap-1.5">
-              <Clock size={12} />
-              Auto-Sync Schedule
-            </p>
-            <div className="grid grid-cols-5 gap-1.5">
-              {Object.entries(INTERVAL_LABELS).map(([value, label]) => (
-                <button
-                  key={value}
-                  onClick={() => handleIntervalChange(value)}
-                  className={`px-2 py-2 rounded-lg text-xs font-medium transition-all ${
-                    interval === value
-                      ? 'bg-indigo-600 text-white shadow-sm'
-                      : 'bg-zinc-800 text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700'
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
-            {interval !== 'off' && (
-              <p className="text-xs text-zinc-600 mt-2">
-                Siftly will automatically sync new bookmarks from X {INTERVAL_LABELS[interval]?.toLowerCase()}
-              </p>
-            )}
-          </div>
         </>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+          {error}
+        </p>
       )}
     </div>
   )
@@ -1357,12 +1326,21 @@ export default function ImportPage() {
 
       if (!res.ok) throw new Error(data.error ?? 'Import failed')
 
+      const imported = data.imported ?? 0
+      const skipped = data.skipped ?? 0
+      const parsed = data.parsed ?? (imported + skipped)
       const result: ImportResult = {
-        imported: data.imported ?? data.count ?? 0,
-        skipped: data.skipped ?? 0,
-        total: (data.imported ?? data.count ?? 0) + (data.skipped ?? 0),
+        imported,
+        skipped,
+        total: imported + skipped,
+        parsed,
       }
       setImportResult(result)
+
+      if (parsed === 0) {
+        // Parser couldn't extract any bookmarks — likely wrong format
+        throw new Error('Could not parse any bookmarks from this file. Make sure you\'re uploading a Twitter/X bookmarks JSON export.')
+      }
 
       // Auto-advance to categorization after a brief moment to show the result
       setTimeout(() => setStep(3), 1500)

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -28,6 +28,14 @@ const ANTHROPIC_MODELS = [
   { value: 'claude-opus-4-6', label: 'Opus 4.6', description: 'Most Capable' },
 ]
 
+const OPENAI_MODELS = [
+  { value: 'gpt-4.1-mini', label: 'GPT-4.1 Mini', description: 'Fast & Cheap' },
+  { value: 'gpt-4.1', label: 'GPT-4.1', description: 'Most Capable' },
+  { value: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', description: 'Fastest' },
+  { value: 'o4-mini', label: 'o4-mini', description: 'Reasoning (mini)' },
+  { value: 'o3', label: 'o3', description: 'Reasoning' },
+]
+
 
 interface Toast {
   type: 'success' | 'error'
@@ -98,7 +106,7 @@ function ApiKeyField({
 }: {
   label: string
   placeholder: string
-  fieldKey: 'anthropicApiKey'
+  fieldKey: 'anthropicApiKey' | 'openaiApiKey'
   hint: string
   docHref: string
   onToast: (t: Toast) => void
@@ -117,7 +125,8 @@ function ApiKeyField({
     fetch('/api/settings')
       .then((r) => r.json())
       .then((d: Record<string, unknown>) => {
-        const hasKey = d['hasAnthropicKey']
+        const hasKeyField = fieldKey === 'openaiApiKey' ? 'hasOpenaiKey' : 'hasAnthropicKey'
+        const hasKey = d[hasKeyField]
         const masked = d[fieldKey] as string | null
         if (hasKey && masked) setSavedMasked(masked)
       })
@@ -296,7 +305,7 @@ function ModelSelector({
   onToast,
 }: {
   models: { value: string; label: string; description: string }[]
-  settingKey: 'anthropicModel'
+  settingKey: 'anthropicModel' | 'openaiModel'
   defaultValue: string
   onToast: (t: Toast) => void
 }) {
@@ -428,36 +437,192 @@ function ClaudeCliStatusBox() {
   )
 }
 
+function CodexCliStatusBox() {
+  const [status, setStatus] = useState<{ available: boolean; expired?: boolean; planType?: string; authMode?: string } | null>(null)
+
+  useEffect(() => {
+    fetch('/api/settings/cli-status')
+      .then((r) => r.json())
+      .then((d: { codex?: { available: boolean; expired?: boolean; planType?: string; authMode?: string } }) => setStatus(d.codex ?? { available: false }))
+      .catch(() => setStatus({ available: false }))
+  }, [])
+
+  if (status === null) return null
+
+  if (status.available && !status.expired) {
+    const tier = status.planType
+      ? status.planType.charAt(0).toUpperCase() + status.planType.slice(1)
+      : 'CLI'
+    return (
+      <div className="flex gap-3 p-3.5 rounded-xl bg-emerald-500/5 border border-emerald-500/20 mb-5">
+        <Check size={15} className="text-emerald-400 shrink-0 mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-emerald-300">
+            Codex CLI detected — no API key needed
+          </p>
+          <p className="text-xs text-zinc-500 mt-0.5 leading-relaxed">
+            Signed in as <span className="text-zinc-300">{tier}</span> via Codex CLI. Siftly will use your credentials automatically. An API key below will take priority if set.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (status.available && status.expired) {
+    return (
+      <div className="flex gap-3 p-3.5 rounded-xl bg-amber-500/5 border border-amber-500/20 mb-5">
+        <AlertCircle size={15} className="text-amber-400 shrink-0 mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-amber-300">Codex CLI session expired</p>
+          <p className="text-xs text-zinc-500 mt-0.5">
+            Run <span className="font-mono text-zinc-300">codex</span> in your terminal to refresh, then reload this page.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex gap-3 p-3.5 rounded-xl bg-zinc-800/60 border border-zinc-700 mb-5">
+      <Terminal size={15} className="text-zinc-400 shrink-0 mt-0.5" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-zinc-200">No Codex CLI detected</p>
+        <p className="text-xs text-zinc-500 mt-0.5 leading-relaxed">
+          Install Codex CLI and sign in to skip the API key entirely, or paste your OpenAI API key below.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai'; onChange: (v: 'anthropic' | 'openai') => void }) {
+  return (
+    <div className="flex items-center gap-1 p-1 rounded-xl bg-zinc-800 border border-zinc-700 mb-5">
+      <button
+        onClick={() => onChange('anthropic')}
+        className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          value === 'anthropic'
+            ? 'bg-indigo-600 text-white shadow-sm'
+            : 'text-zinc-400 hover:text-zinc-200'
+        }`}
+      >
+        Anthropic (Claude)
+      </button>
+      <button
+        onClick={() => onChange('openai')}
+        className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          value === 'openai'
+            ? 'bg-emerald-600 text-white shadow-sm'
+            : 'text-zinc-400 hover:text-zinc-200'
+        }`}
+      >
+        OpenAI (GPT)
+      </button>
+    </div>
+  )
+}
+
 function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
+  const [provider, setProvider] = useState<'anthropic' | 'openai' | null>(null)
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((d: { provider?: string }) => {
+        setProvider(d.provider === 'openai' ? 'openai' : 'anthropic')
+      })
+      .catch(() => setProvider('anthropic'))
+  }, [])
+
+  async function handleProviderChange(newProvider: 'anthropic' | 'openai') {
+    const prev = provider
+    setProvider(newProvider)
+    try {
+      const res = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: newProvider }),
+      })
+      if (!res.ok) throw new Error('Failed to save provider')
+      onToast({ type: 'success', message: `Switched to ${newProvider === 'openai' ? 'OpenAI' : 'Anthropic'}` })
+    } catch {
+      setProvider(prev) // revert on failure
+      onToast({ type: 'error', message: 'Failed to save provider preference' })
+    }
+  }
+
+  // Don't render until we know the saved provider — avoids flicker
+  if (provider === null) {
+    return (
+      <Section
+        icon={Key}
+        title="AI Provider"
+        description="Choose your AI provider and configure keys. CLI auth means no key needed."
+      >
+        <div className="flex items-center gap-2 text-sm text-zinc-500">
+          <Loader2 size={14} className="animate-spin" /> Loading settings…
+        </div>
+      </Section>
+    )
+  }
+
   return (
     <Section
       icon={Key}
       title="AI Provider"
-      description="Configure your AI keys. If Claude Code CLI is installed and signed in, no key is needed."
+      description="Choose your AI provider and configure keys. CLI auth means no key needed."
     >
-      {/* Claude CLI auth status */}
-      <ClaudeCliStatusBox />
+      <ProviderToggle value={provider} onChange={(v) => void handleProviderChange(v)} />
 
-      <div className="space-y-5">
-        <div>
-          <ApiKeyField
-            label="Anthropic (Claude)"
-            placeholder="sk-ant-api03-..."
-            fieldKey="anthropicApiKey"
-            hint="Used for AI categorization, search, and image analysis."
-            docHref="https://console.anthropic.com"
-            onToast={onToast}
-            testProvider="anthropic"
-          />
-          <ModelSelector
-            models={ANTHROPIC_MODELS}
-            settingKey="anthropicModel"
-            defaultValue="claude-opus-4-6"
-            onToast={onToast}
-          />
-          <p className="text-xs text-zinc-500 mt-1.5">Applies to all AI operations — API key <strong className="text-zinc-400 font-medium">and Claude CLI</strong></p>
-        </div>
-      </div>
+      {provider === 'anthropic' ? (
+        <>
+          <ClaudeCliStatusBox />
+          <div className="space-y-5">
+            <div>
+              <ApiKeyField
+                label="Anthropic (Claude)"
+                placeholder="sk-ant-api03-..."
+                fieldKey="anthropicApiKey"
+                hint="Used for AI categorization, search, and image analysis."
+                docHref="https://console.anthropic.com"
+                onToast={onToast}
+                testProvider="anthropic"
+              />
+              <ModelSelector
+                models={ANTHROPIC_MODELS}
+                settingKey="anthropicModel"
+                defaultValue="claude-haiku-4-5-20251001"
+                onToast={onToast}
+              />
+              <p className="text-xs text-zinc-500 mt-1.5">Applies to all AI operations — API key <strong className="text-zinc-400 font-medium">and Claude CLI</strong></p>
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <CodexCliStatusBox />
+          <div className="space-y-5">
+            <div>
+              <ApiKeyField
+                label="OpenAI"
+                placeholder="sk-..."
+                fieldKey="openaiApiKey"
+                hint="Used for AI categorization, search, and image analysis."
+                docHref="https://platform.openai.com/api-keys"
+                onToast={onToast}
+                testProvider="openai"
+              />
+              <ModelSelector
+                models={OPENAI_MODELS}
+                settingKey="openaiModel"
+                defaultValue="gpt-4.1-mini"
+                onToast={onToast}
+              />
+              <p className="text-xs text-zinc-500 mt-1.5">Applies to all AI operations — API key <strong className="text-zinc-400 font-medium">and Codex CLI</strong></p>
+            </div>
+          </div>
+        </>
+      )}
       <p className="text-xs text-zinc-600 mt-4">Keys are stored in plaintext in your local SQLite database (<code className="font-mono">prisma/dev.db</code>). Do not expose the database file.</p>
     </Section>
   )
@@ -591,7 +756,7 @@ function DangerZoneSection({ onToast }: { onToast: (t: Toast) => void }) {
 const TECH_STACK = [
   { label: 'Next.js 15', color: 'bg-zinc-800 text-zinc-300 border-zinc-700' },
   { label: 'Prisma + SQLite', color: 'bg-zinc-800 text-zinc-300 border-zinc-700' },
-  { label: 'Anthropic API', color: 'bg-blue-500/10 text-blue-300 border-blue-500/20' },
+  { label: 'Anthropic / OpenAI', color: 'bg-blue-500/10 text-blue-300 border-blue-500/20' },
   { label: 'React Flow', color: 'bg-zinc-800 text-zinc-300 border-zinc-700' },
   { label: 'Tailwind CSS', color: 'bg-cyan-500/10 text-cyan-300 border-cyan-500/20' },
 ]
@@ -664,6 +829,155 @@ function AboutSection() {
   )
 }
 
+function XOAuthSection({ onToast }: { onToast: (t: Toast) => void }) {
+  const [clientId, setClientId] = useState('')
+  const [clientSecret, setClientSecret] = useState('')
+  const [savedId, setSavedId] = useState<string | null>(null)
+  const [savedSecret, setSavedSecret] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((d: Record<string, unknown>) => {
+        if (d.hasXOAuth && d.xOAuthClientId) setSavedId(d.xOAuthClientId as string)
+        if (d.xOAuthClientSecret) setSavedSecret(d.xOAuthClientSecret as string)
+      })
+      .catch(() => {})
+  }, [])
+
+  async function handleSave() {
+    if (!clientId.trim()) {
+      onToast({ type: 'error', message: 'Client ID is required' })
+      return
+    }
+    setSaving(true)
+    try {
+      const payload: Record<string, string> = { xOAuthClientId: clientId.trim() }
+      if (clientSecret.trim()) payload.xOAuthClientSecret = clientSecret.trim()
+      const res = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(data.error ?? 'Failed to save')
+      }
+      setSavedId(clientId.trim().slice(0, 6) + '••••' + clientId.trim().slice(-4))
+      if (clientSecret.trim()) setSavedSecret(clientSecret.trim().slice(0, 4) + '••••')
+      setClientId('')
+      setClientSecret('')
+      onToast({ type: 'success', message: 'X OAuth credentials saved' })
+    } catch (err) {
+      onToast({ type: 'error', message: err instanceof Error ? err.message : 'Failed to save' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleRemove() {
+    try {
+      await fetch('/api/settings', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'x_oauth_client_id' }),
+      })
+      await fetch('/api/settings', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'x_oauth_client_secret' }),
+      })
+      setSavedId(null)
+      setSavedSecret(null)
+      onToast({ type: 'success', message: 'X OAuth credentials removed' })
+    } catch (err) {
+      onToast({ type: 'error', message: err instanceof Error ? err.message : 'Failed to remove' })
+    }
+  }
+
+  const callbackUrl = typeof window !== 'undefined'
+    ? `${window.location.origin}/api/import/x-oauth/callback`
+    : '/api/import/x-oauth/callback'
+
+  return (
+    <Section
+      icon={Shield}
+      title="X (Twitter) OAuth 2.0"
+      description="Connect your X account to import bookmarks using the official API."
+    >
+      <div className="space-y-4">
+        {savedId ? (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-3 p-3.5 rounded-xl bg-emerald-500/8 border border-emerald-500/20">
+              <div className="flex items-center gap-2.5">
+                <Check size={15} className="text-emerald-400 shrink-0" />
+                <div className="text-sm">
+                  <span className="text-emerald-300">Client ID: </span>
+                  <span className="text-zinc-400 font-mono text-xs">{savedId}</span>
+                  {savedSecret && (
+                    <>
+                      <span className="text-zinc-600 mx-2">·</span>
+                      <span className="text-emerald-300">Secret: </span>
+                      <span className="text-zinc-400 font-mono text-xs">{savedSecret}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+              <button
+                onClick={handleRemove}
+                className="p-1.5 rounded-lg text-zinc-500 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                title="Remove X OAuth credentials"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <input
+                type="text"
+                placeholder="Client ID"
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+                className="w-full px-3 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm placeholder:text-zinc-600 focus:outline-none focus:border-indigo-500/50 font-mono"
+              />
+              <input
+                type="password"
+                placeholder="Client Secret (optional for public clients)"
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
+                className="w-full px-3 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm placeholder:text-zinc-600 focus:outline-none focus:border-indigo-500/50 font-mono"
+              />
+            </div>
+            <button
+              onClick={handleSave}
+              disabled={saving || !clientId.trim()}
+              className="w-full py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors flex items-center justify-center gap-2"
+            >
+              {saving ? <Loader2 size={14} className="animate-spin" /> : <Key size={14} />}
+              {saving ? 'Saving...' : 'Save X OAuth Credentials'}
+            </button>
+          </div>
+        )}
+
+        <div className="text-xs text-zinc-600 space-y-1">
+          <p>
+            Get credentials from the{' '}
+            <a href="https://developer.x.com/en/portal/dashboard" target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">
+              X Developer Portal
+            </a>
+          </p>
+          <p>
+            Callback URL: <code className="bg-zinc-800 px-1.5 py-0.5 rounded font-mono text-zinc-400">{callbackUrl}</code>
+          </p>
+        </div>
+      </div>
+    </Section>
+  )
+}
+
 export default function SettingsPage() {
   const [toast, setToast] = useState<Toast | null>(null)
 
@@ -691,6 +1005,7 @@ export default function SettingsPage() {
 
       <div className="space-y-4">
         <ApiKeySection onToast={showToast} />
+        <XOAuthSection onToast={showToast} />
         <DataSection />
         <DangerZoneSection onToast={showToast} />
         <AboutSection />

--- a/components/bookmark-card.tsx
+++ b/components/bookmark-card.tsx
@@ -33,28 +33,29 @@ interface LinkPreviewData {
 // Module-level cache: url → preview data (or null on error)
 const previewCache = new Map<string, LinkPreviewData | null>()
 
-function LinkPreview({ url, tweetUrl }: { url: string; tweetUrl: string }) {
+function LinkPreview({ url, tweetUrl, tweetId, prominent = false }: { url: string; tweetUrl: string; tweetId?: string; prominent?: boolean }) {
   const [data, setData] = useState<LinkPreviewData | null | 'loading'>('loading')
 
   useEffect(() => {
-    if (previewCache.has(url)) {
-      setData(previewCache.get(url) ?? null)
+    const cacheKey = tweetId ? `${url}:${tweetId}` : url
+    if (previewCache.has(cacheKey)) {
+      setData(previewCache.get(cacheKey) ?? null)
       return
     }
     let cancelled = false
-    fetch(`/api/link-preview?url=${encodeURIComponent(url)}`)
+    fetch(`/api/link-preview?url=${encodeURIComponent(url)}${tweetId ? `&tweetId=${tweetId}` : ''}`)
       .then((r) => r.json())
       .then((d: LinkPreviewData & { error?: string }) => {
         if (cancelled) return
         const result = d.error || !d.title ? null : d
-        previewCache.set(url, result)
+        previewCache.set(cacheKey, result)
         setData(result)
       })
       .catch(() => {
-        if (!cancelled) { previewCache.set(url, null); setData(null) }
+        if (!cancelled) { previewCache.set(cacheKey, null); setData(null) }
       })
     return () => { cancelled = true }
-  }, [url])
+  }, [url, tweetId])
 
   if (data === 'loading') {
     return (
@@ -66,11 +67,11 @@ function LinkPreview({ url, tweetUrl }: { url: string; tweetUrl: string }) {
   if (!data) {
     return (
       <a
-        href={url}
+        href={tweetUrl}
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
-        className="mt-2 inline-flex items-center gap-1.5 px-3 py-2 rounded-xl border border-zinc-800 bg-zinc-800/40 hover:border-zinc-700 hover:bg-zinc-800/70 transition-all text-xs text-zinc-400 hover:text-zinc-200 max-w-full overflow-hidden"
+        className={`${prominent ? 'mt-1' : 'mt-2'} inline-flex items-center gap-1.5 px-3 py-2 rounded-xl border border-zinc-800 bg-zinc-800/40 hover:border-zinc-700 hover:bg-zinc-800/70 transition-all text-xs text-zinc-400 hover:text-zinc-200 max-w-full overflow-hidden`}
       >
         <Globe size={11} className="shrink-0 text-zinc-600" />
         <span className="truncate">{url.replace(/^https?:\/\//, '')}</span>
@@ -79,7 +80,76 @@ function LinkPreview({ url, tweetUrl }: { url: string; tweetUrl: string }) {
     )
   }
 
+  // X article pages return useless OG data — show a styled "View article" card instead
+  const isGenericXArticle = (data.domain === 'x.com' || data.domain === 'twitter.com') && !data.image && !data.description
+
   const href = data.url || url
+
+  // X article / generic X link with no useful OG data — show a clean "View on X" card
+  if (isGenericXArticle) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className={`${prominent ? 'mt-1' : 'mt-2'} flex items-center gap-3 overflow-hidden rounded-xl border border-zinc-800 bg-zinc-800/40 hover:border-zinc-700 hover:bg-zinc-800/70 transition-all group/link px-4 py-3`}
+      >
+        <div className="w-10 h-10 rounded-lg bg-zinc-700/60 flex items-center justify-center shrink-0">
+          <svg viewBox="0 0 24 24" className="w-5 h-5 text-zinc-400" fill="currentColor">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-zinc-200 group-hover/link:text-white transition-colors">
+            {data.title?.includes('Article') ? 'View Article on X' : data.title || 'View on X'}
+          </p>
+          <p className="text-xs text-zinc-500 truncate">{data.domain}{data.url ? new URL(data.url).pathname : ''}</p>
+        </div>
+        <ExternalLink size={14} className="text-zinc-600 group-hover/link:text-zinc-400 transition-colors shrink-0" />
+      </a>
+    )
+  }
+
+  // Prominent mode: vertical layout with large image — used for link-only bookmarks
+  if (prominent) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className="mt-1 flex flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-800/40 hover:border-zinc-700 hover:bg-zinc-800/70 transition-all group/link"
+      >
+        {data.image && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={data.image}
+            alt=""
+            className="w-full h-40 object-cover border-b border-zinc-800"
+            loading="lazy"
+            onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+          />
+        )}
+        <div className="flex flex-col px-3 py-2.5 min-w-0 gap-1">
+          <p className="text-sm font-semibold text-zinc-200 line-clamp-2 group-hover/link:text-white transition-colors leading-snug">
+            {data.title}
+          </p>
+          {data.description && (
+            <p className="text-xs text-zinc-400 line-clamp-3 leading-relaxed">
+              {data.description}
+            </p>
+          )}
+          <div className="flex items-center gap-1 mt-0.5">
+            <Globe size={10} className="text-zinc-600 shrink-0" />
+            <span className="text-[10px] text-zinc-600 truncate">
+              {data.siteName || data.domain}
+            </span>
+          </div>
+        </div>
+      </a>
+    )
+  }
 
   return (
     <a
@@ -646,7 +716,7 @@ export default function BookmarkCard({ bookmark }: BookmarkCardProps) {
             <p className="text-xs text-zinc-700 italic">No text content</p>
           )}
           {previewUrl && (
-            <LinkPreview url={previewUrl} tweetUrl={tweetUrl} />
+            <LinkPreview url={previewUrl} tweetUrl={tweetUrl} tweetId={bookmark.tweetId} prominent={!displayText} />
           )}
         </div>
 

--- a/lib/ai-client.ts
+++ b/lib/ai-client.ts
@@ -1,0 +1,115 @@
+import Anthropic from '@anthropic-ai/sdk'
+import OpenAI from 'openai'
+import { resolveAnthropicClient } from './claude-cli-auth'
+import { resolveOpenAIClient } from './openai-auth'
+import { getProvider } from './settings'
+
+export interface AIContentBlock {
+  type: 'text' | 'image'
+  text?: string
+  source?: { type: 'base64'; media_type: string; data: string }
+}
+
+export interface AIMessage {
+  role: 'user' | 'assistant'
+  content: string | AIContentBlock[]
+}
+
+export interface AIResponse {
+  text: string
+}
+
+export interface AIClient {
+  provider: 'anthropic' | 'openai'
+  createMessage(params: {
+    model: string
+    max_tokens: number
+    messages: AIMessage[]
+  }): Promise<AIResponse>
+}
+
+// Wrap Anthropic SDK
+export class AnthropicAIClient implements AIClient {
+  provider = 'anthropic' as const
+  constructor(private sdk: Anthropic) {}
+
+  async createMessage(params: { model: string; max_tokens: number; messages: AIMessage[] }): Promise<AIResponse> {
+    const messages = params.messages.map(m => {
+      if (typeof m.content === 'string') {
+        return { role: m.role as 'user' | 'assistant', content: m.content }
+      }
+      const blocks = m.content.map(b => {
+        if (b.type === 'image' && b.source) {
+          return {
+            type: 'image' as const,
+            source: {
+              type: 'base64' as const,
+              media_type: b.source.media_type as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+              data: b.source.data,
+            },
+          }
+        }
+        return { type: 'text' as const, text: b.text ?? '' }
+      })
+      return { role: m.role as 'user' | 'assistant', content: blocks }
+    })
+
+    const msg = await this.sdk.messages.create({
+      model: params.model,
+      max_tokens: params.max_tokens,
+      messages,
+    })
+
+    const textBlock = msg.content.find(b => b.type === 'text')
+    return { text: textBlock && 'text' in textBlock ? textBlock.text : '' }
+  }
+}
+
+// Wrap OpenAI SDK
+export class OpenAIAIClient implements AIClient {
+  provider = 'openai' as const
+  constructor(private sdk: OpenAI) {}
+
+  async createMessage(params: { model: string; max_tokens: number; messages: AIMessage[] }): Promise<AIResponse> {
+    const messages: OpenAI.ChatCompletionMessageParam[] = params.messages.map((m): OpenAI.ChatCompletionMessageParam => {
+      if (typeof m.content === 'string') {
+        if (m.role === 'assistant') return { role: 'assistant' as const, content: m.content }
+        return { role: 'user' as const, content: m.content }
+      }
+      const parts: OpenAI.ChatCompletionContentPart[] = m.content.map(b => {
+        if (b.type === 'image' && b.source) {
+          return {
+            type: 'image_url' as const,
+            image_url: { url: `data:${b.source.media_type};base64,${b.source.data}` },
+          }
+        }
+        return { type: 'text' as const, text: b.text ?? '' }
+      })
+      if (m.role === 'assistant') return { role: 'assistant' as const, content: parts.map(p => p.type === 'text' ? p : p).filter((p): p is OpenAI.ChatCompletionContentPartText => p.type === 'text') }
+      return { role: 'user' as const, content: parts }
+    })
+
+    const completion = await this.sdk.chat.completions.create({
+      model: params.model,
+      max_tokens: params.max_tokens,
+      messages,
+    })
+
+    return { text: completion.choices[0]?.message?.content ?? '' }
+  }
+}
+
+export async function resolveAIClient(options: {
+  overrideKey?: string
+  dbKey?: string
+} = {}): Promise<AIClient> {
+  const provider = await getProvider()
+
+  if (provider === 'openai') {
+    const client = resolveOpenAIClient(options)
+    return new OpenAIAIClient(client)
+  }
+
+  const client = resolveAnthropicClient(options)
+  return new AnthropicAIClient(client)
+}

--- a/lib/categorizer.ts
+++ b/lib/categorizer.ts
@@ -1,8 +1,9 @@
-import Anthropic from '@anthropic-ai/sdk'
 import prisma from '@/lib/db'
 import { buildImageContext } from '@/lib/image-context'
-import { resolveAnthropicClient, getCliAvailability, claudePrompt, modelNameToCliAlias } from '@/lib/claude-cli-auth'
-import { getAnthropicModel } from '@/lib/settings'
+import { getCliAvailability, claudePrompt, modelNameToCliAlias } from '@/lib/claude-cli-auth'
+import { getCodexCliAvailability, codexPrompt } from '@/lib/codex-cli'
+import { getActiveModel, getProvider } from '@/lib/settings'
+import { AIClient, resolveAIClient } from '@/lib/ai-client'
 
 const BATCH_SIZE = 20
 
@@ -209,7 +210,7 @@ ${JSON.stringify(tweetData, null, 1)}`
 
 function parseCategorizationResponse(text: string, validSlugs: Set<string>): CategorizationResult[] {
   const jsonMatch = text.match(/\[[\s\S]*\]/)
-  if (!jsonMatch) throw new Error('No JSON array found in Claude response')
+  if (!jsonMatch) throw new Error('No JSON array found in AI response')
 
   const parsed: unknown = JSON.parse(jsonMatch[0])
   if (!Array.isArray(parsed)) throw new Error('Claude response is not an array')
@@ -231,47 +232,62 @@ function parseCategorizationResponse(text: string, validSlugs: Set<string>): Cat
 
 export async function categorizeBatch(
   bookmarks: BookmarkForCategorization[],
-  client: Anthropic | null,
+  client: AIClient | null,
   categoryDescriptions: Record<string, string> = {},
   allSlugs: string[] = DEFAULT_SLUGS,
 ): Promise<CategorizationResult[]> {
   if (bookmarks.length === 0) return []
 
   const prompt = buildCategorizationPrompt(bookmarks, categoryDescriptions, allSlugs)
+  const provider = await getProvider()
 
   // Prefer CLI over SDK (avoids OAuth token extraction, uses CLI directly)
-  if (await getCliAvailability()) {
-    const modelSetting = await getAnthropicModel()
-    const cliModel = modelNameToCliAlias(modelSetting)
-
-    const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 60_000 })
-    if (result.success && result.data) {
-      try {
-        return parseCategorizationResponse(result.data, new Set(allSlugs))
-      } catch (parseErr) {
-        console.warn('[categorize] CLI response parse failed, falling back to SDK:', parseErr)
+  if (provider === 'openai') {
+    if (await getCodexCliAvailability()) {
+      const result = await codexPrompt(prompt, { timeoutMs: 60_000 })
+      if (result.success && result.data) {
+        try {
+          return parseCategorizationResponse(result.data, new Set(allSlugs))
+        } catch (parseErr) {
+          console.warn('[categorize] Codex CLI response parse failed, falling back to SDK:', parseErr)
+        }
+      } else {
+        console.warn('[categorize] Codex CLI failed, falling back to SDK:', result.error)
       }
-    } else {
-      console.warn('[categorize] CLI failed, falling back to SDK:', result.error)
+    }
+  } else {
+    if (await getCliAvailability()) {
+      const model = await getActiveModel()
+      const cliModel = modelNameToCliAlias(model)
+
+      const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 60_000 })
+      if (result.success && result.data) {
+        try {
+          return parseCategorizationResponse(result.data, new Set(allSlugs))
+        } catch (parseErr) {
+          console.warn('[categorize] CLI response parse failed, falling back to SDK:', parseErr)
+        }
+      } else {
+        console.warn('[categorize] CLI failed, falling back to SDK:', result.error)
+      }
     }
   }
 
   // Fallback to SDK (requires API key)
   if (!client) {
-    throw new Error('Claude CLI not available and no API key configured.')
+    throw new Error('No CLI available and no API key configured.')
   }
 
-  const model = await getAnthropicModel()
-  const message = await client.messages.create({
+  const model = await getActiveModel()
+  const response = await client.createMessage({
     model,
     max_tokens: 2048,
     messages: [{ role: 'user', content: prompt }],
   })
 
-  const textBlock = message.content.find((b) => b.type === 'text')
-  if (!textBlock || textBlock.type !== 'text') throw new Error('No text content in Claude response')
+  if (!response.text) throw new Error('No text content in AI response')
 
-  return parseCategorizationResponse(textBlock.text, new Set(allSlugs))
+  return parseCategorizationResponse(response.text, new Set(allSlugs))
 }
 
 export async function writeCategoryResults(results: CategorizationResult[]): Promise<void> {
@@ -382,8 +398,15 @@ export async function categorizeAll(
   await seedDefaultCategories()
 
   // Resolve auth once — avoids re-resolving inside every batch call
-  const apiKeySetting = await prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } })
-  const client = resolveAnthropicClient({ dbKey: apiKeySetting?.value })
+  const provider = await getProvider()
+  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const apiKeySetting = await prisma.setting.findUnique({ where: { key: keyName } })
+  let client: AIClient | null = null
+  try {
+    client = await resolveAIClient({ dbKey: apiKeySetting?.value })
+  } catch {
+    // CLI might still work — client stays null
+  }
 
   // Load ALL categories (default + custom) for the prompt
   const dbCategories = await prisma.category.findMany({ select: { slug: true, name: true, description: true } })

--- a/lib/codex-cli.ts
+++ b/lib/codex-cli.ts
@@ -1,0 +1,95 @@
+import { execFile, spawn } from 'child_process'
+import { promisify } from 'util'
+import { readFileSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const execFileAsync = promisify(execFile)
+
+export interface CodexCliOptions {
+  model?: string
+  timeoutMs?: number
+}
+
+export interface CodexCliResult<T = unknown> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export async function isCodexCliAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = spawn('codex', ['--version'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    const timeout = setTimeout(() => { proc.kill(); resolve(false) }, 5000)
+    proc.on('close', (code) => { clearTimeout(timeout); resolve(code === 0) })
+    proc.on('error', () => { clearTimeout(timeout); resolve(false) })
+  })
+}
+
+export async function codexPrompt(
+  prompt: string,
+  options: CodexCliOptions = {}
+): Promise<CodexCliResult<string>> {
+  const { model, timeoutMs = 120_000 } = options
+
+  // Write output to a temp file so we can capture the model's final message cleanly
+  const outFile = join(tmpdir(), `codex-out-${randomUUID()}.txt`)
+
+  const args = ['exec', '--output-last-message', outFile]
+  if (model) args.push('--model', model)
+  args.push(prompt)
+
+  try {
+    await execFileAsync('codex', args, {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+      windowsHide: true,
+    })
+
+    // Read the captured output
+    try {
+      const output = readFileSync(outFile, 'utf8').trim()
+      try { unlinkSync(outFile) } catch { /* ignore cleanup errors */ }
+      return { success: true, data: output }
+    } catch {
+      try { unlinkSync(outFile) } catch { /* ignore */ }
+      return { success: false, error: 'Codex exec completed but no output file found' }
+    }
+  } catch (err) {
+    // If the process ran but output was written before the error, try reading it
+    try {
+      const output = readFileSync(outFile, 'utf8').trim()
+      try { unlinkSync(outFile) } catch { /* ignore */ }
+      if (output) {
+        return { success: true, data: output }
+      }
+    } catch { /* no output file */ }
+
+    try { unlinkSync(outFile) } catch { /* ignore */ }
+    return { success: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+let _cliAvailable: boolean | null = null
+let _cliCheckTime = 0
+let _cliCheckPromise: Promise<boolean> | null = null
+const CLI_CHECK_TTL_MS = 60_000
+
+export async function getCodexCliAvailability(): Promise<boolean> {
+  const now = Date.now()
+  if (_cliAvailable !== null && now - _cliCheckTime < CLI_CHECK_TTL_MS) return _cliAvailable
+  if (_cliCheckPromise) return _cliCheckPromise
+
+  _cliCheckPromise = isCodexCliAvailable().then((result) => {
+    _cliAvailable = result
+    _cliCheckTime = Date.now()
+    _cliCheckPromise = null
+    return result
+  })
+  return _cliCheckPromise
+}

--- a/lib/openai-auth.ts
+++ b/lib/openai-auth.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import OpenAI from 'openai'
+
+interface CodexAuth {
+  auth_mode?: string
+  OPENAI_API_KEY?: string | null
+  tokens?: {
+    access_token?: string
+    refresh_token?: string
+    account_id?: string
+  }
+}
+
+let cachedAuth: CodexAuth | null = null
+let cacheReadAt = 0
+const CACHE_TTL_MS = 60_000
+
+function readCodexAuthFile(): CodexAuth | null {
+  const paths = [
+    join(homedir(), '.codex', 'auth.json'),
+    join(homedir(), '.config', 'codex', 'auth.json'),
+  ]
+  for (const p of paths) {
+    try {
+      const raw = readFileSync(p, 'utf8')
+      const parsed = JSON.parse(raw) as CodexAuth
+      if (parsed.tokens?.access_token || parsed.OPENAI_API_KEY) return parsed
+    } catch { continue }
+  }
+  return null
+}
+
+function readCodexAuth(): CodexAuth | null {
+  const now = Date.now()
+  if (cachedAuth && now - cacheReadAt < CACHE_TTL_MS) return cachedAuth
+
+  const auth = readCodexAuthFile()
+  cachedAuth = auth
+  cacheReadAt = now
+  return auth
+}
+
+/**
+ * Returns the Codex auth mode. When 'chatgpt', the token only works
+ * through `codex exec`, not the OpenAI SDK directly.
+ */
+export function getCodexAuthMode(): 'api_key' | 'chatgpt' | null {
+  const auth = readCodexAuth()
+  if (!auth) return null
+  if (auth.OPENAI_API_KEY) return 'api_key'
+  if (auth.auth_mode === 'chatgpt' && auth.tokens?.access_token) return 'chatgpt'
+  if (auth.tokens?.access_token) return 'api_key'
+  return null
+}
+
+function getCodexApiKey(): string | null {
+  const auth = readCodexAuth()
+  if (!auth) return null
+
+  // Explicit API key takes priority
+  if (auth.OPENAI_API_KEY) return auth.OPENAI_API_KEY
+
+  // ChatGPT OAuth tokens don't work with the OpenAI SDK directly —
+  // they need the `codex exec` CLI path. Don't return them here.
+  if (auth.auth_mode === 'chatgpt') return null
+
+  // Non-ChatGPT OAuth token (API key mode)
+  if (auth.tokens?.access_token) return auth.tokens.access_token
+
+  return null
+}
+
+export function getCodexCliAuthStatus(): {
+  available: boolean
+  expired?: boolean
+  authMode?: string
+  planType?: string
+} {
+  const auth = readCodexAuth()
+  if (!auth) return { available: false }
+
+  const key = auth.OPENAI_API_KEY || auth.tokens?.access_token
+  if (!key) return { available: false }
+
+  // Try to extract plan type from JWT for display
+  let planType: string | undefined
+  if (auth.tokens?.access_token) {
+    try {
+      const payload = JSON.parse(
+        Buffer.from(auth.tokens.access_token.split('.')[1], 'base64').toString()
+      ) as { exp?: number; 'https://api.openai.com/auth'?: { chatgpt_plan_type?: string } }
+
+      planType = payload['https://api.openai.com/auth']?.chatgpt_plan_type
+
+      // Check if token is expired
+      if (payload.exp && Date.now() / 1000 > payload.exp) {
+        return { available: true, expired: true, authMode: auth.auth_mode, planType }
+      }
+    } catch { /* ignore parse errors */ }
+  }
+
+  return { available: true, authMode: auth.auth_mode, planType }
+}
+
+function createCodexOpenAIClient(baseURL?: string): OpenAI | null {
+  const apiKey = getCodexApiKey()
+  if (!apiKey) return null
+  return new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) })
+}
+
+export function resolveOpenAIClient(options: {
+  overrideKey?: string
+  dbKey?: string
+  baseURL?: string
+} = {}): OpenAI {
+  const baseURL = options.baseURL ?? process.env.OPENAI_BASE_URL
+
+  if (options.overrideKey?.trim()) {
+    return new OpenAI({ apiKey: options.overrideKey.trim(), ...(baseURL ? { baseURL } : {}) })
+  }
+
+  if (options.dbKey?.trim()) {
+    return new OpenAI({ apiKey: options.dbKey.trim(), ...(baseURL ? { baseURL } : {}) })
+  }
+
+  const cliClient = createCodexOpenAIClient(baseURL)
+  if (cliClient) return cliClient
+
+  const envKey = process.env.OPENAI_API_KEY?.trim()
+  if (envKey) return new OpenAI({ apiKey: envKey, ...(baseURL ? { baseURL } : {}) })
+
+  if (baseURL) return new OpenAI({ apiKey: 'proxy', baseURL })
+
+  throw new Error('No OpenAI API key found. Add your key in Settings, or set up Codex CLI.')
+}

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -251,6 +251,42 @@ function convertConsoleExportRow(row: ConsoleExportBookmark): RawTweet {
   }
 }
 
+interface SiftlyExportItem {
+  tweetId?: string
+  text?: string
+  authorHandle?: string
+  authorName?: string
+  tweetCreatedAt?: string
+  mediaItems?: { type?: string; url?: string; thumbnailUrl?: string }[]
+  [key: string]: unknown
+}
+
+function isSiftlyExportFormat(item: unknown): item is SiftlyExportItem {
+  if (typeof item !== 'object' || item === null) return false
+  return 'tweetId' in item && 'text' in item
+}
+
+function convertSiftlyExportRow(row: SiftlyExportItem): RawTweet {
+  const mediaEntities: TwitterMediaEntity[] = (row.mediaItems ?? [])
+    .filter((m) => m.url)
+    .map((m) => {
+      const type = m.type === 'video' ? 'video' : m.type === 'gif' ? 'animated_gif' : 'photo'
+      if (type === 'video' || type === 'animated_gif') {
+        return { type, media_url_https: m.url, video_info: { variants: [{ content_type: 'video/mp4', bitrate: 0, url: m.url! }] } }
+      }
+      return { type, media_url_https: m.url }
+    })
+
+  return {
+    id_str: row.tweetId,
+    full_text: row.text,
+    created_at: row.tweetCreatedAt,
+    user: { screen_name: row.authorHandle || 'unknown', name: row.authorName || 'Unknown' },
+    entities: { media: mediaEntities.length > 0 ? mediaEntities : undefined },
+    extended_entities: mediaEntities.length > 0 ? { media: mediaEntities } : undefined,
+  }
+}
+
 function normalizeTweetArray(parsed: unknown): RawTweet[] {
   // Console script export format: { exportDate, totalBookmarks, bookmarks: [...] }
   if (isConsoleExportFormat(parsed)) {
@@ -260,6 +296,10 @@ function normalizeTweetArray(parsed: unknown): RawTweet[] {
   if (Array.isArray(parsed)) {
     if (parsed.length > 0 && isFlatExportFormat(parsed[0])) {
       return parsed.map((row) => convertFlatExportRow(row as FlatExportRow))
+    }
+    // Siftly re-export format: [{ tweetId, text, authorHandle, ... }]
+    if (parsed.length > 0 && isSiftlyExportFormat(parsed[0])) {
+      return parsed.map((row) => convertSiftlyExportRow(row as SiftlyExportItem))
     }
     return parsed as RawTweet[]
   }

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,8 +1,16 @@
 import prisma from '@/lib/db'
 
-// Module-level model cache — avoids hundreds of DB roundtrips per pipeline run
+// Module-level caches — avoids hundreds of DB roundtrips per pipeline run
 let _cachedModel: string | null = null
 let _modelCacheExpiry = 0
+
+let _cachedProvider: 'anthropic' | 'openai' | null = null
+let _providerCacheExpiry = 0
+
+let _cachedOpenAIModel: string | null = null
+let _openAIModelCacheExpiry = 0
+
+const CACHE_TTL = 5 * 60 * 1000
 
 /**
  * Get the configured Anthropic model from settings (cached for 5 minutes).
@@ -11,6 +19,48 @@ export async function getAnthropicModel(): Promise<string> {
   if (_cachedModel && Date.now() < _modelCacheExpiry) return _cachedModel
   const setting = await prisma.setting.findUnique({ where: { key: 'anthropicModel' } })
   _cachedModel = setting?.value ?? 'claude-haiku-4-5-20251001'
-  _modelCacheExpiry = Date.now() + 5 * 60 * 1000
+  _modelCacheExpiry = Date.now() + CACHE_TTL
   return _cachedModel
+}
+
+/**
+ * Get the active AI provider (cached for 5 minutes).
+ */
+export async function getProvider(): Promise<'anthropic' | 'openai'> {
+  if (_cachedProvider && Date.now() < _providerCacheExpiry) return _cachedProvider
+  const setting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
+  _cachedProvider = setting?.value === 'openai' ? 'openai' : 'anthropic'
+  _providerCacheExpiry = Date.now() + CACHE_TTL
+  return _cachedProvider
+}
+
+/**
+ * Get the configured OpenAI model from settings (cached for 5 minutes).
+ */
+export async function getOpenAIModel(): Promise<string> {
+  if (_cachedOpenAIModel && Date.now() < _openAIModelCacheExpiry) return _cachedOpenAIModel
+  const setting = await prisma.setting.findUnique({ where: { key: 'openaiModel' } })
+  _cachedOpenAIModel = setting?.value ?? 'gpt-4.1-mini'
+  _openAIModelCacheExpiry = Date.now() + CACHE_TTL
+  return _cachedOpenAIModel
+}
+
+/**
+ * Get the model for the currently active provider.
+ */
+export async function getActiveModel(): Promise<string> {
+  const provider = await getProvider()
+  return provider === 'openai' ? getOpenAIModel() : getAnthropicModel()
+}
+
+/**
+ * Clear all settings caches (call after settings are changed).
+ */
+export function invalidateSettingsCache(): void {
+  _cachedModel = null
+  _modelCacheExpiry = 0
+  _cachedProvider = null
+  _providerCacheExpiry = 0
+  _cachedOpenAIModel = null
+  _openAIModelCacheExpiry = 0
 }

--- a/lib/vision-analyzer.ts
+++ b/lib/vision-analyzer.ts
@@ -1,10 +1,11 @@
-import Anthropic from '@anthropic-ai/sdk'
 import prisma from '@/lib/db'
 import { buildImageContext } from '@/lib/image-context'
 import { getCliAvailability, claudePrompt, modelNameToCliAlias } from '@/lib/claude-cli-auth'
-import { getAnthropicModel } from '@/lib/settings'
+import { getCodexCliAvailability, codexPrompt } from '@/lib/codex-cli'
+import { getActiveModel, getProvider } from '@/lib/settings'
+import { AIClient } from '@/lib/ai-client'
 
-export { getAnthropicModel } from '@/lib/settings'
+export { getActiveModel } from '@/lib/settings'
 
 type AllowedMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'
 
@@ -69,17 +70,52 @@ Rules:
 const RETRY_DELAYS_MS = [1500, 4000, 10000]
 const CONCURRENCY = 12
 
+/**
+ * CLI-based vision analysis: passes the image URL in the prompt text.
+ * Works with Codex CLI (ChatGPT OAuth) and Claude CLI without needing SDK access.
+ */
+async function analyzeImageViaCli(imageUrl: string): Promise<string> {
+  const provider = await getProvider()
+  // Sanitize URL: strip control characters and newlines to prevent prompt injection
+  const safeUrl = imageUrl.replace(/[\r\n\t]/g, '').trim()
+  if (!safeUrl.startsWith('http://') && !safeUrl.startsWith('https://')) return ''
+  const urlPrompt = `Look at this image URL and analyze it: ${safeUrl}\n\n${ANALYSIS_PROMPT}`
+
+  if (provider === 'openai') {
+    if (!(await getCodexCliAvailability())) return ''
+    const result = await codexPrompt(urlPrompt, { timeoutMs: 60_000 })
+    if (!result.success || !result.data) return ''
+    const jsonMatch = result.data.match(/\{[\s\S]*\}/)
+    if (!jsonMatch) return ''
+    try { JSON.parse(jsonMatch[0]); return jsonMatch[0] } catch { return '' }
+  } else {
+    if (!(await getCliAvailability())) return ''
+    const model = await getActiveModel()
+    const cliModel = modelNameToCliAlias(model)
+    const result = await claudePrompt(urlPrompt, { model: cliModel, timeoutMs: 60_000 })
+    if (!result.success || !result.data) return ''
+    const jsonMatch = result.data.match(/\{[\s\S]*\}/)
+    if (!jsonMatch) return ''
+    try { JSON.parse(jsonMatch[0]); return jsonMatch[0] } catch { return '' }
+  }
+}
+
 async function analyzeImageWithRetry(
   url: string,
-  client: Anthropic,
+  client: AIClient | null,
   model: string,
   attempt = 0,
 ): Promise<string> {
+  // If no SDK client, use CLI path with image URL
+  if (!client) {
+    return attempt === 0 ? analyzeImageViaCli(url) : ''
+  }
+
   const img = await fetchImageAsBase64(url)
   if (!img) return ''
 
   try {
-    const msg = await client.messages.create({
+    const response = await client.createMessage({
       model,
       max_tokens: 700,
       messages: [
@@ -92,7 +128,7 @@ async function analyzeImageWithRetry(
         },
       ],
     })
-    const raw = msg.content.find((b) => b.type === 'text')?.text?.trim() ?? ''
+    const raw = response.text?.trim() ?? ''
     if (!raw) return ''
 
     // Validate it's parseable JSON
@@ -101,26 +137,25 @@ async function analyzeImageWithRetry(
     JSON.parse(jsonMatch[0]) // throws if invalid
     return jsonMatch[0]
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const errMsg = err instanceof Error ? err.message : String(err)
     // Never retry client errors (4xx) — bad request, invalid image, too large, etc.
-    const isClientError = msg.includes('400') || msg.includes('401') || msg.includes('403') || msg.includes('422')
+    const isClientError = errMsg.includes('400') || errMsg.includes('401') || errMsg.includes('403') || errMsg.includes('422')
     const isRetryable =
       !isClientError && (
-        msg.includes('rate') ||
-        msg.includes('529') ||
-        msg.includes('overloaded') ||
-        msg.includes('ECONNREFUSED') ||
-        msg.includes('ETIMEDOUT') ||
-        msg.includes('fetch') ||
-        msg.includes('network') ||
-        msg.includes('500') ||
-        msg.includes('502') ||
-        msg.includes('503')
+        errMsg.includes('rate') ||
+        errMsg.includes('529') ||
+        errMsg.includes('overloaded') ||
+        errMsg.includes('ECONNREFUSED') ||
+        errMsg.includes('ETIMEDOUT') ||
+        errMsg.includes('fetch') ||
+        errMsg.includes('network') ||
+        errMsg.includes('500') ||
+        errMsg.includes('502') ||
+        errMsg.includes('503')
       )
 
     if (attempt === 0) {
-      // Log first failure per item so server console shows what's wrong
-      console.warn(`[vision] analysis failed (attempt ${attempt + 1}): ${msg.slice(0, 120)}`)
+      console.warn(`[vision] analysis failed (attempt ${attempt + 1}): ${errMsg.slice(0, 120)}`)
     }
 
     if (isRetryable && attempt < RETRY_DELAYS_MS.length) {
@@ -152,7 +187,7 @@ async function getCachedAnalysis(imageUrl: string, excludeId: string): Promise<s
 
 export async function analyzeItem(
   item: MediaItemForAnalysis,
-  client: Anthropic,
+  client: AIClient | null,
   model: string,
 ): Promise<number> {
   const imageUrl = item.type === 'video' ? (item.thumbnailUrl ?? item.url) : item.url
@@ -204,14 +239,14 @@ export async function runWithConcurrency<T>(
 
 export async function analyzeBatch(
   items: MediaItemForAnalysis[],
-  client: Anthropic,
+  client: AIClient | null,
   onProgress?: (delta: number) => void,
   shouldAbort?: () => boolean,
 ): Promise<number> {
   const analyzable = items.filter((m) => m.type === 'photo' || m.type === 'gif' || m.type === 'video')
   if (analyzable.length === 0) return 0
 
-  const model = await getAnthropicModel()
+  const model = await getActiveModel()
 
   const tasks = analyzable.map((item) => async () => {
     if (shouldAbort?.()) return 0
@@ -224,7 +259,7 @@ export async function analyzeBatch(
   return results.reduce((sum, r) => sum + r, 0)
 }
 
-export async function analyzeUntaggedImages(client: Anthropic, limit = 10): Promise<number> {
+export async function analyzeUntaggedImages(client: AIClient, limit = 10): Promise<number> {
   const untagged = await prisma.mediaItem.findMany({
     where: { imageTags: null, type: { in: ['photo', 'gif', 'video'] } },
     take: limit,
@@ -238,7 +273,7 @@ export async function analyzeUntaggedImages(client: Anthropic, limit = 10): Prom
  * Analyze ALL untagged media items (no limit). Used during full AI categorization.
  */
 export async function analyzeAllUntagged(
-  client: Anthropic,
+  client: AIClient,
   onProgress?: (total: number) => void,
   shouldAbort?: () => boolean,
 ): Promise<number> {
@@ -338,11 +373,12 @@ ${JSON.stringify(items, null, 1)}`
 
 export async function enrichBatchSemanticTags(
   bookmarks: BookmarkForEnrichment[],
-  client: Anthropic | null,
+  client: AIClient | null,
 ): Promise<EnrichmentResult[]> {
   if (bookmarks.length === 0) return []
 
   const prompt = buildEnrichmentPrompt(bookmarks)
+  const provider = await getProvider()
 
   // Helper to parse enrichment response
   const parseResponse = (text: string): EnrichmentResult[] => {
@@ -360,16 +396,23 @@ export async function enrichBatchSemanticTags(
   }
 
   // Prefer CLI over SDK
-  if (await getCliAvailability()) {
-    const modelSetting = await getAnthropicModel()
-    const cliModel = modelNameToCliAlias(modelSetting)
+  if (provider === 'openai') {
+    if (await getCodexCliAvailability()) {
+      const result = await codexPrompt(prompt, { timeoutMs: 90_000 })
+      if (result.success && result.data) {
+        try { return parseResponse(result.data) }
+        catch { console.warn('[enrich] Codex CLI response parse failed, falling back to SDK') }
+      }
+    }
+  } else {
+    if (await getCliAvailability()) {
+      const model = await getActiveModel()
+      const cliModel = modelNameToCliAlias(model)
 
-    const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 90_000 })
-    if (result.success && result.data) {
-      try {
-        return parseResponse(result.data)
-      } catch {
-        console.warn('[enrich] CLI response parse failed, falling back to SDK')
+      const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 90_000 })
+      if (result.success && result.data) {
+        try { return parseResponse(result.data) }
+        catch { console.warn('[enrich] CLI response parse failed, falling back to SDK') }
       }
     }
   }
@@ -380,18 +423,17 @@ export async function enrichBatchSemanticTags(
     return []
   }
 
-  const model = await getAnthropicModel()
+  const model = await getActiveModel()
   const ENRICH_RETRY_DELAYS = [2000, 5000]
 
   for (let attempt = 0; attempt <= ENRICH_RETRY_DELAYS.length; attempt++) {
     try {
-      const msg = await client.messages.create({
+      const response = await client.createMessage({
         model,
         max_tokens: 4096,
         messages: [{ role: 'user', content: prompt }],
       })
-      const text = msg.content.find((b) => b.type === 'text')?.text ?? ''
-      const results = parseResponse(text)
+      const results = parseResponse(response.text)
       if (results.length > 0) return results
       console.warn(`[enrich] no JSON array in response (attempt ${attempt + 1})`)
     } catch (err) {
@@ -411,7 +453,7 @@ export async function enrichBatchSemanticTags(
  * with ENRICH_CONCURRENCY parallel batches — 5-10x fewer API calls vs. per-bookmark.
  */
 export async function enrichAllBookmarks(
-  client: Anthropic,
+  client: AIClient,
   onProgress?: (total: number) => void,
   shouldAbort?: () => boolean,
 ): Promise<number> {
@@ -520,7 +562,7 @@ export async function enrichBookmarkSemanticTags(
   bookmarkId: string,
   tweetText: string,
   imageTags: string[],
-  client: Anthropic,
+  client: AIClient,
   entities?: BookmarkForEnrichment['entities'],
 ): Promise<string[]> {
   const results = await enrichBatchSemanticTags(


### PR DESCRIPTION
## Summary

- **OpenAI/Codex CLI support**: Add dual-provider architecture (Anthropic + OpenAI) with CLI-first fallback. Codex CLI users with ChatGPT OAuth can use all features without an API key — categorization, enrichment, vision analysis, and AI search all route through `codex exec` when no SDK client is available.
- **Import parser fix**: Add Siftly re-export format support (`tweetId`, `text`, `authorHandle`, `mediaItems` fields). Show proper error when parser can't extract bookmarks instead of misleading "Already up to date".
- **Article previews**: Use Twitter syndication API to fetch rich article data (title, preview text, cover image) for X article bookmarks. Prominent layout for link-only cards.
- **Security fixes**: SSRF validation on redirected URLs, tweetId param validation, crypto-secure temp file names, sanitized image URLs in CLI prompts.
- **Performance**: Pipeline concurrency lowered from 20 → 5 workers to avoid rate limits.

### New files
- `lib/ai-client.ts` — AIClient abstraction wrapping both SDKs
- `lib/codex-cli.ts` — Codex CLI wrapper (`codex exec --output-last-message`)
- `lib/openai-auth.ts` — Codex credential resolution from `~/.codex/auth.json`

### Modified files (15)
Settings, categorizer, vision analyzer, search, import, link-preview, bookmark card, parser

## Test plan
- [x] TypeScript type check passes
- [x] Production build succeeds
- [x] Import parser handles Siftly re-export format (692 bookmarks)
- [x] Categorization pipeline works via Codex CLI
- [x] Article bookmark cards show cover image and preview text via syndication API
- [x] Code audit: all critical/high issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)