### PR TITLE
style: fix edit dialog overflow on masonry items

### DIFF
--- a/components/bookmark-card.tsx
+++ b/components/bookmark-card.tsx
@@ -630,11 +630,11 @@ export default function BookmarkCard({ bookmark }: BookmarkCardProps) {
     (firstMedia.type === 'photo' || isVideoUrl(firstMedia.url))
 
   return (
-    <div className="group relative bg-zinc-900 border border-zinc-800 rounded-2xl hover:border-zinc-700 hover:shadow-xl hover:shadow-black/30 transition-all duration-200 overflow-hidden flex flex-col flex-1">
+    <div className="group relative bg-zinc-900 border border-zinc-800 rounded-2xl hover:border-zinc-700 hover:shadow-xl hover:shadow-black/30 transition-all duration-200 flex flex-col flex-1">
 
       {/* Top media — full bleed, no padding */}
       {firstMedia && (
-        <div className="border-b border-zinc-800/60 flex-shrink-0">
+        <div className="border-b border-zinc-800/60 rounded-t-2xl overflow-hidden shrink-0">
           <TopMediaSlot item={firstMedia} tweetUrl={tweetUrl} />
         </div>
       )}


### PR DESCRIPTION
<img width="500" alt="screenshot" src="https://github.com/user-attachments/assets/ada75fac-8275-409a-b2cf-e8898f171a35" />


## Summary
Fix edit dialog overflow on masonry bookmark cards by moving overflow-hidden from the card container to the media slot.

## Changes
- Removed overflow-hidden from the card root `<div>` so dialogs/popovers aren't clipped by the card boundary
- Added `overflow-hidden` + `rounded-t-2xl` to the media wrapper to keep images properly contained
- Replaced `flex-shrink-0` with `shrink-0`

## Related Issues
none

## Checklist
- [x] Tested locally
- [x] `npx tsc --noEmit` passes
- [x] No new warnings