### PR TITLE
Add OpenCode AI provider support

### DIFF
--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,0 +1,183 @@
+# Siftly — OpenCode Edition
+
+Self-hosted Twitter/X bookmark manager with AI-powered categorization, search, and visualization.
+
+**This version is configured for OpenCode integration.**
+
+## Quick Setup
+
+```bash
+./start.sh            # installs deps, sets up DB, opens browser
+```
+
+Or manually:
+
+```bash
+npm install
+npx prisma generate && npx prisma db push
+npx next dev
+```
+
+App runs at **http://localhost:3000**
+
+## AI Authentication — OpenCode Integration
+
+This Siftly installation is configured to work with **OpenCode**, the AI coding assistant.
+
+### Automatic Detection
+
+Siftly automatically detects OpenCode authentication from `~/.config/opencode/auth.json`:
+
+- **OpenCode API Key** — reads `opencode.key` from your OpenCode config
+- **OpenAI Token** — reads `openai.access` or `openai.key` from OpenCode config
+- **GitHub Copilot** — (if available)
+
+### Configuration Options
+
+1. **OpenCode Provider** (Recommended)
+   - Go to **Settings** in Siftly
+   - Select **OpenCode** as the AI provider
+   - No API key needed if OpenCode is installed — Siftly reads auth automatically
+
+2. **Manual OpenCode Key**
+   - If auto-detection doesn't work, get your OpenCode API key from `~/.config/opencode/auth.json`
+   - Add it to Settings → OpenCode API Key
+
+3. **Fallback: Anthropic/OpenAI**
+   - If you prefer, you can still use Anthropic or OpenAI directly
+   - Select the provider in Settings and add your API key
+
+## Key Commands
+
+```bash
+npx next dev          # Start dev server (port 3000)
+npx tsc --noEmit      # Type check
+npx prisma studio     # Database GUI
+npx prisma db push    # Apply schema changes to DB
+npm run build         # Production build
+```
+
+## Project Structure
+
+```
+app/
+  api/
+    categorize/       # 4-stage AI pipeline (start/stop/status via SSE)
+    import/           # Bookmark JSON import + dedup
+    search/ai/        # FTS5 + semantic search
+    settings/
+      cli-status/     # GET — returns AI auth status (includes OpenCode)
+      test/           # POST — validates API key or CLI auth
+    analyze/images/   # Vision analysis progress + trigger
+    bookmarks/        # CRUD + filtering
+    categories/       # Category management
+    mindmap/          # Graph data
+    stats/            # Dashboard counts
+  import/             # 3-step import UI
+  mindmap/            # Interactive force graph
+  settings/           # API keys, model selection
+  ai-search/          # Natural language search UI
+  bookmarks/          # Browse + filter UI
+  categorize/         # Pipeline monitor
+
+lib/
+  opencode-auth.ts   # OpenCode auth detection (~/.config/opencode/auth.json)
+  claude-cli-auth.ts # Claude CLI OAuth session
+  openai-auth.ts     # OpenAI/Codex CLI auth
+  ai-client.ts       # Unified AI client (Anthropic/OpenAI/OpenCode)
+  categorizer.ts     # AI categorization + default categories
+  vision-analyzer.ts # Image vision + semantic tagging
+  fts.ts             # SQLite FTS5 full-text search
+  rawjson-extractor.ts # Entity extraction from tweet JSON
+  parser.ts          # Multi-format bookmark JSON parser
+  exporter.ts        # CSV / JSON / ZIP export
+  settings.ts        # Settings cache + provider selection
+
+prisma/schema.prisma  # SQLite schema (Bookmark, Category, MediaItem, Setting, ImportJob)
+```
+
+## AI Providers
+
+Siftly now supports three AI providers:
+
+| Provider | Auth Method | Auto-Detection |
+|----------|-------------|----------------|
+| **OpenCode** | `~/.config/opencode/auth.json` | Yes |
+| **Anthropic** | Claude CLI or API key | Yes (Claude CLI) |
+| **OpenAI** | Codex CLI or API key | Yes (Codex CLI) |
+
+Switch providers in **Settings** without losing data.
+
+## Environment Variables
+
+```bash
+# Database (optional, has default)
+DATABASE_URL="file:./prisma/dev.db"
+
+# OpenCode base URL (optional, has default)
+OPENCODE_BASE_URL="https://api.opencode.ai/v1"
+```
+
+## CLI Tool
+
+`cli/siftly.ts` provides direct database access without the Next.js server:
+
+```bash
+npx tsx cli/siftly.ts stats                          # Library statistics
+npx tsx cli/siftly.ts categories                     # Categories with counts
+npx tsx cli/siftly.ts search "AI agents"             # FTS5 keyword search
+npx tsx cli/siftly.ts list --limit 5                 # Recent bookmarks
+npx tsx cli/siftly.ts show <id|tweetId>              # Full bookmark detail
+npm run siftly -- stats                              # Alternative via npm script
+```
+
+## Common Tasks
+
+| Task | How |
+|------|-----|
+| Run AI pipeline | `POST /api/categorize` with `{}` body; `GET /api/categorize` for SSE progress |
+| Add category | Edit `DEFAULT_CATEGORIES` in `lib/categorizer.ts` |
+| Add known tool | Append domain to `KNOWN_TOOL_DOMAINS` in `lib/rawjson-extractor.ts` |
+| Test OpenCode auth | `POST /api/settings/test` with `{"provider":"opencode"}` |
+| Check CLI auth | `GET /api/settings/cli-status` |
+| Switch AI provider | Go to Settings → Provider → Select OpenCode/Anthropic/OpenAI |
+
+## Database
+
+SQLite at `prisma/dev.db`. After schema changes: `npx prisma db push`
+
+Models: `Bookmark`, `MediaItem`, `BookmarkCategory`, `Category`, `Setting`, `ImportJob`
+
+## OpenCode-Specific Changes
+
+1. **New Files:**
+   - `lib/opencode-auth.ts` — Reads OpenCode auth from `~/.config/opencode/auth.json`
+
+2. **Modified Files:**
+   - `lib/ai-client.ts` — Added OpenCode provider support
+   - `lib/settings.ts` — Added 'opencode' provider type
+   - `app/api/settings/route.ts` — Added OpenCode model/key endpoints
+   - `app/api/settings/test/route.ts` — Added OpenCode test
+   - `app/api/settings/cli-status/route.ts` — Added OpenCode status
+
+3. **Models Supported:**
+   - `gpt-4.1-mini` (default)
+   - `gpt-4.1`
+   - `claude-haiku-4-5-20251001`
+   - `claude-sonnet-4-6`
+
+## Troubleshooting
+
+**OpenCode not detected?**
+- Check `~/.config/opencode/auth.json` exists
+- Verify the file has `opencode.key` or `openai.access` fields
+- Try restarting Siftly after OpenCode login
+
+**API errors?**
+- Check Settings → Test API Key
+- Verify your OpenCode subscription/plan has API access
+- Check browser console for detailed error messages
+
+---
+
+*Built by @viperr • OpenCode Integration by OpenCode*

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ After the pipeline runs, you get:
 - [Node.js 18+](https://nodejs.org)
 - npm (comes with Node.js)
 
-**That's it.** If you have [Claude Code CLI](https://claude.ai/code) installed and signed in, AI features work automatically — no API key needed.
+**That's it.** If you have [Claude Code CLI](https://claude.ai/code) or [OpenCode](https://opencode.ai) installed, AI features work automatically — no API key needed.
 
 ### Option A — One command (recommended)
 
@@ -61,7 +61,7 @@ cd Siftly
 ./start.sh
 ```
 
-`start.sh` installs dependencies, sets up the database, checks for Claude CLI auth, and opens [http://localhost:3000](http://localhost:3000) automatically.
+`start.sh` installs dependencies, sets up the database, checks for Claude CLI or OpenCode auth, and opens [http://localhost:3000](http://localhost:3000) automatically.
 
 ### Option B — Using Claude Code
 
@@ -98,9 +98,10 @@ Siftly automatically detects the best available auth method — no configuration
 | # | Method | How |
 |---|--------|-----|
 | 1 | **Claude Code CLI** *(zero config)* | Already signed in? Siftly reads your session from the macOS keychain automatically |
-| 2 | **API key in Settings** | Open Settings in the app and paste your key |
-| 3 | **`ANTHROPIC_API_KEY` env var** | Set in `.env.local` or your shell environment |
-| 4 | **Local proxy** | Set `ANTHROPIC_BASE_URL` to any Anthropic-compatible endpoint |
+| 2 | **OpenCode** *(zero config)* | OpenCode installed? Siftly reads `~/.config/opencode/auth.json` automatically |
+| 3 | **API key in Settings** | Open Settings in the app and paste your key |
+| 4 | **`ANTHROPIC_API_KEY` env var** | Set in `.env.local` or your shell environment |
+| 5 | **Local proxy** | Set `ANTHROPIC_BASE_URL` to any Anthropic-compatible endpoint |
 
 ### Claude Code CLI (no API key needed)
 
@@ -109,6 +110,12 @@ If you use [Claude Code](https://claude.ai/code), you're already signed in. Sift
 The Settings page shows a green **"Claude CLI detected — no API key needed"** badge with your subscription tier when this is active.
 
 > **Note:** This works on macOS. On Linux/Windows, add an API key in Settings instead.
+
+### OpenCode (no API key needed)
+
+If you use [OpenCode](https://opencode.ai), Siftly automatically reads your auth credentials from `~/.config/opencode/auth.json` and uses your OpenCode subscription.
+
+Select **OpenCode** as the AI provider in Settings. Siftly will use OpenCode's AI models for categorization, search, and analysis.
 
 ### Getting an API key (if needed)
 
@@ -237,10 +244,12 @@ All settings are manageable in the **Settings** page at `/settings` or via envir
 
 | Setting | Env Var | Description |
 |---------|---------|-------------|
-| Anthropic API Key | `ANTHROPIC_API_KEY` | Optional if Claude CLI is signed in — otherwise required for AI features |
-| API Base URL | `ANTHROPIC_BASE_URL` | Custom endpoint for proxies or local Anthropic-compatible models |
-| AI Model | Settings page only | Haiku 4.5 (default, fastest/cheapest), Sonnet 4.6, Opus 4.6 |
-| OpenAI Key | Settings page only | Alternative provider if no Anthropic key is set |
+| AI Provider | Settings page only | Choose between `anthropic`, `openai`, or `opencode` |
+| Anthropic API Key | `ANTHROPIC_API_KEY` | Optional if Claude CLI is signed in |
+| OpenAI API Key | `OPENAI_API_KEY` | Optional if Codex CLI is signed in |
+| OpenCode | Auto-detected | Reads from `~/.config/opencode/auth.json` |
+| API Base URL | `ANTHROPIC_BASE_URL` | Custom endpoint for proxies |
+| AI Model | Settings page only | Model selection based on provider |
 | Database | `DATABASE_URL` | SQLite file path (default: `file:./prisma/dev.db`) |
 
 ### Custom API Endpoint
@@ -302,6 +311,9 @@ siftly/
 ├── lib/
 │   ├── categorizer.ts        # AI categorization logic + default categories
 │   ├── claude-cli-auth.ts    # Claude CLI OAuth session detection (macOS keychain)
+│   ├── opencode-auth.ts      # OpenCode auth detection (~/.config/opencode/auth.json)
+│   ├── openai-auth.ts        # OpenAI/Codex CLI auth
+│   ├── ai-client.ts          # Unified AI client (Anthropic/OpenAI/OpenCode)
 │   ├── vision-analyzer.ts    # Image analysis + batch semantic tagging
 │   ├── image-context.ts      # Shared image context builder
 │   ├── fts.ts                # SQLite FTS5 full-text search index
@@ -315,7 +327,8 @@ siftly/
 │   └── schema.prisma         # SQLite schema
 │
 ├── start.sh                  # One-command launcher (install + DB setup + open browser)
-└── CLAUDE.md                 # Instructions for Claude Code AI assistant
+├── CLAUDE.md                 # Instructions for Claude Code AI assistant
+└── OPENCODE.md               # Instructions for OpenCode AI assistant
 ```
 
 ### Database Schema
@@ -354,6 +367,7 @@ For Prisma command and workflow details, see:
 | [SQLite](https://sqlite.org) | — | Local database — zero setup, includes FTS5 |
 | [Tailwind CSS](https://tailwindcss.com) | v4 | Styling |
 | [Anthropic SDK](https://docs.anthropic.com) | — | Vision, semantic tagging, categorization, search |
+| [OpenAI SDK](https://platform.openai.com) | — | Alternative AI provider (Codex, OpenCode) |
 | [@xyflow/react](https://xyflow.com) | 12 | Interactive mindmap graph |
 | [Framer Motion](https://www.framer.com/motion/) | 12 | Animations |
 | [Radix UI](https://www.radix-ui.com) | — | Accessible UI primitives |

--- a/app/api/settings/cli-status/route.ts
+++ b/app/api/settings/cli-status/route.ts
@@ -2,15 +2,17 @@ import { NextResponse } from 'next/server'
 import prisma from '@/lib/db'
 import { getCliAuthStatus, getCliAvailability } from '@/lib/claude-cli-auth'
 import { getCodexCliAuthStatus } from '@/lib/openai-auth'
+import { getOpencodeAuthStatus } from '@/lib/opencode-auth'
 
 export async function GET(): Promise<NextResponse> {
   const oauthStatus = getCliAuthStatus()
   const codexStatus = getCodexCliAuthStatus()
+  const opencodeStatus = getOpencodeAuthStatus()
 
   // Read provider directly from DB (not cached) — this endpoint is called
   // right after the user toggles the provider, so it must be fresh.
   const providerSetting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
-  const provider = providerSetting?.value === 'openai' ? 'openai' : 'anthropic'
+  const provider = providerSetting?.value ?? 'anthropic'
 
   // Only check CLI subprocess availability if OAuth credentials exist
   const cliDirectAvailable = oauthStatus.available && !oauthStatus.expired
@@ -22,6 +24,7 @@ export async function GET(): Promise<NextResponse> {
     cliDirectAvailable,
     mode: cliDirectAvailable ? 'cli' : oauthStatus.available ? 'oauth' : 'api-key',
     codex: codexStatus,
+    opencode: opencodeStatus,
     provider,
   })
 }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -22,14 +22,23 @@ const ALLOWED_OPENAI_MODELS = [
   'o3',
 ] as const
 
+const ALLOWED_OPENCODE_MODELS = [
+  'gpt-4.1-mini',
+  'gpt-4.1',
+  'claude-haiku-4-5-20251001',
+  'claude-sonnet-4-6',
+] as const
+
 export async function GET(): Promise<NextResponse> {
   try {
-    const [anthropic, anthropicModel, provider, openai, openaiModel, xClientId, xClientSecret] = await Promise.all([
+    const [anthropic, anthropicModel, provider, openai, openaiModel, opencode, opencodeModel, xClientId, xClientSecret] = await Promise.all([
       prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'anthropicModel' } }),
       prisma.setting.findUnique({ where: { key: 'aiProvider' } }),
       prisma.setting.findUnique({ where: { key: 'openaiApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'openaiModel' } }),
+      prisma.setting.findUnique({ where: { key: 'opencodeApiKey' } }),
+      prisma.setting.findUnique({ where: { key: 'opencodeModel' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_id' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_secret' } }),
     ])
@@ -42,6 +51,9 @@ export async function GET(): Promise<NextResponse> {
       openaiApiKey: maskKey(openai?.value ?? null),
       hasOpenaiKey: openai !== null,
       openaiModel: openaiModel?.value ?? 'gpt-4.1-mini',
+      opencodeApiKey: maskKey(opencode?.value ?? null),
+      hasOpencodeKey: opencode !== null,
+      opencodeModel: opencodeModel?.value ?? 'gpt-4.1-mini',
       xOAuthClientId: maskKey(xClientId?.value ?? null),
       xOAuthClientSecret: maskKey(xClientSecret?.value ?? null),
       hasXOAuth: !!xClientId?.value,
@@ -62,6 +74,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     provider?: string
     openaiApiKey?: string
     openaiModel?: string
+    opencodeApiKey?: string
+    opencodeModel?: string
     xOAuthClientId?: string
     xOAuthClientSecret?: string
   } = {}
@@ -71,11 +85,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const { anthropicApiKey, anthropicModel, provider, openaiApiKey, openaiModel } = body
+  const { anthropicApiKey, anthropicModel, provider, openaiApiKey, openaiModel, opencodeApiKey, opencodeModel } = body
 
   // Save provider if provided
   if (provider !== undefined) {
-    if (provider !== 'anthropic' && provider !== 'openai') {
+    if (!['anthropic', 'openai', 'opencode'].includes(provider)) {
       return NextResponse.json({ error: 'Invalid provider' }, { status: 400 })
     }
     await prisma.setting.upsert({
@@ -110,6 +124,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       where: { key: 'openaiModel' },
       update: { value: openaiModel },
       create: { key: 'openaiModel', value: openaiModel },
+    })
+    invalidateSettingsCache()
+    return NextResponse.json({ saved: true })
+  }
+
+  // Save OpenCode model if provided
+  if (opencodeModel !== undefined) {
+    if (!(ALLOWED_OPENCODE_MODELS as readonly string[]).includes(opencodeModel)) {
+      return NextResponse.json({ error: 'Invalid OpenCode model' }, { status: 400 })
+    }
+    await prisma.setting.upsert({
+      where: { key: 'opencodeModel' },
+      update: { value: opencodeModel },
+      create: { key: 'opencodeModel', value: opencodeModel },
     })
     invalidateSettingsCache()
     return NextResponse.json({ saved: true })
@@ -161,6 +189,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
   }
 
+  // Save OpenCode key if provided
+  if (opencodeApiKey !== undefined) {
+    if (typeof opencodeApiKey !== 'string' || opencodeApiKey.trim() === '') {
+      return NextResponse.json({ error: 'Invalid opencodeApiKey value' }, { status: 400 })
+    }
+    const trimmed = opencodeApiKey.trim()
+    try {
+      await prisma.setting.upsert({
+        where: { key: 'opencodeApiKey' },
+        update: { value: trimmed },
+        create: { key: 'opencodeApiKey', value: trimmed },
+      })
+      invalidateSettingsCache()
+      return NextResponse.json({ saved: true })
+    } catch (err) {
+      console.error('Settings POST (opencode) error:', err)
+      return NextResponse.json(
+        { error: `Failed to save: ${err instanceof Error ? err.message : String(err)}` },
+        { status: 500 }
+      )
+    }
+  }
+
   // Save X OAuth credentials if provided
   const { xOAuthClientId, xOAuthClientSecret } = body
   const xKeys: { key: string; value: string | undefined }[] = [
@@ -198,7 +249,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const allowed = ['anthropicApiKey', 'openaiApiKey', 'x_oauth_client_id', 'x_oauth_client_secret']
+  const allowed = ['anthropicApiKey', 'openaiApiKey', 'opencodeApiKey', 'x_oauth_client_id', 'x_oauth_client_secret']
   if (!body.key || !allowed.includes(body.key)) {
     return NextResponse.json({ error: 'Invalid key' }, { status: 400 })
   }

--- a/app/api/settings/test/route.ts
+++ b/app/api/settings/test/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db'
 import { resolveAnthropicClient, getCliAuthStatus } from '@/lib/claude-cli-auth'
 import { resolveOpenAIClient } from '@/lib/openai-auth'
+import { getOpencodeApiKey, getOpenaiTokenFromOpencode } from '@/lib/opencode-auth'
+import OpenAI from 'openai'
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: { provider?: string } = {}
@@ -57,6 +59,36 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     } catch {
       return NextResponse.json({ working: false, error: 'No OpenAI API key found. Add one in Settings or set up Codex CLI.' })
     }
+
+    try {
+      await client.chat.completions.create({
+        model: 'gpt-4.1-mini',
+        max_tokens: 5,
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+      return NextResponse.json({ working: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      const friendly = msg.includes('401') || msg.includes('invalid_api_key')
+        ? 'Invalid API key'
+        : msg.includes('403')
+        ? 'Key does not have permission'
+        : msg.slice(0, 120)
+      return NextResponse.json({ working: false, error: friendly })
+    }
+  }
+
+  if (provider === 'opencode') {
+    const setting = await prisma.setting.findUnique({ where: { key: 'opencodeApiKey' } })
+    const dbKey = setting?.value?.trim()
+    const apiKey = dbKey ?? getOpencodeApiKey() ?? getOpenaiTokenFromOpencode()
+
+    if (!apiKey) {
+      return NextResponse.json({ working: false, error: 'No OpenCode API key found. Check your OpenCode installation or add a key in Settings.' })
+    }
+
+    const baseURL = process.env.OPENCODE_BASE_URL ?? 'https://api.opencode.ai/v1'
+    const client = new OpenAI({ apiKey, baseURL })
 
     try {
       await client.chat.completions.create({

--- a/lib/ai-client.ts
+++ b/lib/ai-client.ts
@@ -2,7 +2,8 @@ import Anthropic from '@anthropic-ai/sdk'
 import OpenAI from 'openai'
 import { resolveAnthropicClient } from './claude-cli-auth'
 import { resolveOpenAIClient } from './openai-auth'
-import { getProvider } from './settings'
+import { getProvider, getOpencodeModel } from './settings'
+import { getOpencodeApiKey, getOpenaiTokenFromOpencode } from './opencode-auth'
 
 export interface AIContentBlock {
   type: 'text' | 'image'
@@ -20,7 +21,7 @@ export interface AIResponse {
 }
 
 export interface AIClient {
-  provider: 'anthropic' | 'openai'
+  provider: 'anthropic' | 'openai' | 'opencode'
   createMessage(params: {
     model: string
     max_tokens: number
@@ -67,7 +68,7 @@ export class AnthropicAIClient implements AIClient {
 
 // Wrap OpenAI SDK
 export class OpenAIAIClient implements AIClient {
-  provider = 'openai' as const
+  provider: 'openai' | 'opencode' = 'openai'
   constructor(private sdk: OpenAI) {}
 
   async createMessage(params: { model: string; max_tokens: number; messages: AIMessage[] }): Promise<AIResponse> {
@@ -104,6 +105,18 @@ export async function resolveAIClient(options: {
   dbKey?: string
 } = {}): Promise<AIClient> {
   const provider = await getProvider()
+
+  if (provider === 'opencode') {
+    // OpenCode uses OpenAI-compatible API
+    const apiKey = options.overrideKey ?? options.dbKey ?? getOpencodeApiKey() ?? getOpenaiTokenFromOpencode()
+    if (!apiKey) {
+      throw new Error('No OpenCode API key found. Check your OpenCode installation or add a key in Settings.')
+    }
+    // OpenCode uses OpenAI SDK with custom base URL
+    const baseURL = process.env.OPENCODE_BASE_URL ?? 'https://api.opencode.ai/v1'
+    const client = new OpenAI({ apiKey, baseURL })
+    return new OpenAIAIClient(client)
+  }
 
   if (provider === 'openai') {
     const client = resolveOpenAIClient(options)

--- a/lib/opencode-auth.ts
+++ b/lib/opencode-auth.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+interface OpencodeAuth {
+  type: 'api' | 'oauth'
+  key?: string
+  access?: string
+  refresh?: string
+  expires?: number
+}
+
+interface OpencodeConfig {
+  opencode?: OpencodeAuth
+  openai?: OpencodeAuth
+  'github-copilot'?: OpencodeAuth
+  'zai-coding-plan'?: OpencodeAuth
+  'bailian-coding-plan'?: OpencodeAuth
+}
+
+let cachedAuth: OpencodeConfig | null = null
+let cacheReadAt = 0
+const CACHE_TTL_MS = 60_000
+
+function readOpencodeAuthFile(): OpencodeConfig | null {
+  const paths = [
+    join(homedir(), '.config', 'opencode', 'auth.json'),
+    join(homedir(), '.opencode', 'auth.json'),
+  ]
+  for (const p of paths) {
+    try {
+      const raw = readFileSync(p, 'utf8')
+      const parsed = JSON.parse(raw) as OpencodeConfig
+      return parsed
+    } catch { continue }
+  }
+  return null
+}
+
+function readOpencodeAuth(): OpencodeConfig | null {
+  const now = Date.now()
+  if (cachedAuth && now - cacheReadAt < CACHE_TTL_MS) return cachedAuth
+
+  const auth = readOpencodeAuthFile()
+  cachedAuth = auth
+  cacheReadAt = now
+  return auth
+}
+
+/**
+ * Returns the OpenCode API key if available.
+ */
+export function getOpencodeApiKey(): string | null {
+  const auth = readOpencodeAuth()
+  if (!auth?.opencode?.key) return null
+  return auth.opencode.key
+}
+
+/**
+ * Returns the available OpenAI token from OpenCode auth (OAuth or API key).
+ */
+export function getOpenaiTokenFromOpencode(): string | null {
+  const auth = readOpencodeAuth()
+  if (!auth?.openai) return null
+
+  // Return access token if available and not expired
+  if (auth.openai.access) {
+    if (auth.openai.expires && Date.now() > auth.openai.expires) {
+      // Token expired
+      return null
+    }
+    return auth.openai.access
+  }
+
+  return auth.openai.key || null
+}
+
+/**
+ * Returns auth status for the settings UI.
+ */
+export function getOpencodeAuthStatus(): {
+  available: boolean
+  expired?: boolean
+  hasOpencodeKey: boolean
+  hasOpenaiToken: boolean
+  hasCopilot?: boolean
+} {
+  const auth = readOpencodeAuth()
+  if (!auth) return { available: false, hasOpencodeKey: false, hasOpenaiToken: false }
+
+  const hasOpencodeKey = !!auth.opencode?.key
+  const hasOpenaiToken = !!auth.openai?.access || !!auth.openai?.key
+  const hasCopilot = !!auth['github-copilot']?.access
+
+  // Check if OpenAI token is expired
+  let expired = false
+  if (auth.openai?.expires && Date.now() > auth.openai.expires) {
+    expired = true
+  }
+
+  return {
+    available: hasOpencodeKey || hasOpenaiToken,
+    expired,
+    hasOpencodeKey,
+    hasOpenaiToken,
+    hasCopilot,
+  }
+}
+
+/**
+ * Resolves the best available API key/token from OpenCode.
+ * Priority: OpenCode API key > OpenAI token
+ */
+export function resolveOpencodeToken(): string | null {
+  // Try OpenCode API key first
+  const opencodeKey = getOpencodeApiKey()
+  if (opencodeKey) return opencodeKey
+
+  // Fall back to OpenAI token
+  return getOpenaiTokenFromOpencode()
+}

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -4,11 +4,14 @@ import prisma from '@/lib/db'
 let _cachedModel: string | null = null
 let _modelCacheExpiry = 0
 
-let _cachedProvider: 'anthropic' | 'openai' | null = null
+let _cachedProvider: 'anthropic' | 'openai' | 'opencode' | null = null
 let _providerCacheExpiry = 0
 
 let _cachedOpenAIModel: string | null = null
 let _openAIModelCacheExpiry = 0
+
+let _cachedOpencodeModel: string | null = null
+let _opencodeModelCacheExpiry = 0
 
 const CACHE_TTL = 5 * 60 * 1000
 
@@ -26,10 +29,11 @@ export async function getAnthropicModel(): Promise<string> {
 /**
  * Get the active AI provider (cached for 5 minutes).
  */
-export async function getProvider(): Promise<'anthropic' | 'openai'> {
+export async function getProvider(): Promise<'anthropic' | 'openai' | 'opencode'> {
   if (_cachedProvider && Date.now() < _providerCacheExpiry) return _cachedProvider
   const setting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
-  _cachedProvider = setting?.value === 'openai' ? 'openai' : 'anthropic'
+  const value = setting?.value
+  _cachedProvider = value === 'opencode' ? 'opencode' : value === 'openai' ? 'openai' : 'anthropic'
   _providerCacheExpiry = Date.now() + CACHE_TTL
   return _cachedProvider
 }
@@ -46,10 +50,22 @@ export async function getOpenAIModel(): Promise<string> {
 }
 
 /**
+ * Get the configured OpenCode model from settings (cached for 5 minutes).
+ */
+export async function getOpencodeModel(): Promise<string> {
+  if (_cachedOpencodeModel && Date.now() < _opencodeModelCacheExpiry) return _cachedOpencodeModel
+  const setting = await prisma.setting.findUnique({ where: { key: 'opencodeModel' } })
+  _cachedOpencodeModel = setting?.value ?? 'gpt-4.1-mini'
+  _opencodeModelCacheExpiry = Date.now() + CACHE_TTL
+  return _cachedOpencodeModel
+}
+
+/**
  * Get the model for the currently active provider.
  */
 export async function getActiveModel(): Promise<string> {
   const provider = await getProvider()
+  if (provider === 'opencode') return getOpencodeModel()
   return provider === 'openai' ? getOpenAIModel() : getAnthropicModel()
 }
 
@@ -63,4 +79,6 @@ export function invalidateSettingsCache(): void {
   _providerCacheExpiry = 0
   _cachedOpenAIModel = null
   _openAIModelCacheExpiry = 0
+  _cachedOpencodeModel = null
+  _opencodeModelCacheExpiry = 0
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "jszip": "^3.10.1",
         "lucide-react": "^0.576.0",
         "next": "16.1.6",
+        "openai": "^6.27.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "tailwind-merge": "^3.5.0"
@@ -105,6 +106,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -365,7 +367,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -3236,6 +3239,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3246,6 +3250,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3295,6 +3300,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3852,6 +3858,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4285,6 +4292,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4665,6 +4673,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5255,6 +5264,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5440,6 +5450,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6278,6 +6289,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7851,6 +7863,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.27.0.tgz",
+      "integrity": "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8107,6 +8140,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.4.2",
         "@prisma/dev": "0.20.0",
@@ -8269,6 +8303,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8278,6 +8313,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9268,6 +9304,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9468,6 +9505,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9833,6 +9871,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jszip": "^3.10.1",
     "lucide-react": "^0.576.0",
     "next": "16.1.6",
+    "openai": "^6.27.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.5.0"


### PR DESCRIPTION
## Summary

This PR adds support for **OpenCode** as an AI provider alongside Anthropic and OpenAI.

## Changes

### New Files
- `lib/opencode-auth.ts` - Reads OpenCode auth from `~/.config/opencode/auth.json`
- `OPENCODE.md` - Documentation for OpenCode integration

### Modified Files
- `lib/ai-client.ts` - Added OpenCode provider support using OpenAI-compatible API
- `lib/settings.ts` - Added 'opencode' as valid provider type with model selection
- `app/api/settings/route.ts` - Added OpenCode key/model endpoints
- `app/api/settings/test/route.ts` - Added OpenCode API testing
- `app/api/settings/cli-status/route.ts` - Added OpenCode status detection
- `README.md` - Updated with OpenCode info

## Features

- **Auto-detection**: Siftly automatically detects OpenCode auth from `~/.config/opencode/auth.json`
- **API Key support**: Reads OpenCode API key, OpenAI token, or GitHub Copilot credentials
- **Model selection**: Supports GPT-4.1-mini, GPT-4.1, Claude Haiku, Claude Sonnet
- **Provider switching**: Seamlessly switch between Anthropic, OpenAI, and OpenCode in Settings

## Testing

Tested and verified:
- OpenCode auth detection works
- Provider switching functions correctly
- API key validation passes
- AI features work with OpenCode provider

## Usage

Users can select **OpenCode** as their AI provider in Settings. If OpenCode is installed, no API key is needed - Siftly reads auth automatically. Otherwise, users can manually add their OpenCode API key.