### PR TITLE
Feat: Add basic export flow for Obsidian.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,20 @@ It runs a **4-stage AI pipeline** on your bookmarks:
     ↓
 🏷️  Entity Extraction   — mines hashtags, URLs, mentions, and 100+ known tools from raw tweet data (free, zero API calls)
     ↓
-👁️  Vision Analysis      — reads text, objects, and context from every image/GIF/video thumbnail (30–40 visual tags per image)
+👁️  Vision Analysis      — reads text, objects, and context from every image/GIF/video thumbnail
     ↓
-🧠 Semantic Tagging     — generates 25–35 searchable tags per bookmark for AI-powered search
+🧠 Semantic Tagging     — generates broad, reusable search tags per bookmark for AI-powered search
     ↓
 📂 Categorization       — assigns each bookmark to 1–3 categories with confidence scores
+    ↓
+📖 Obsidian Export      — writes your knowledge base as Markdown notes with YAML frontmatter, wikilinks, and index files
 ```
 
 After the pipeline runs, you get:
 - **AI search** — find bookmarks by meaning, not just keywords (*"funny meme about crypto crashing"*)
 - **Interactive mindmap** — explore your entire bookmark graph visually
 - **Filtered browsing** — grid or list view, filter by category, media type, and date
-- **Export tools** — download media, export as CSV / JSON / ZIP
+- **Export tools** — download media, export as CSV / JSON / ZIP / Obsidian vault
 
 ---
 
@@ -224,6 +226,45 @@ Create custom categories with a name, color, and optional description. The descr
 - **CSV** — spreadsheet-compatible with all fields
 - **JSON** — full structured data export
 - **ZIP** — exports a category's bookmarks + all media files with a `manifest.csv`
+- **Obsidian** — exports your entire knowledge base as a Markdown vault (see below)
+
+### 📖 Obsidian Export
+
+Export all processed bookmarks directly into an [Obsidian](https://obsidian.md) vault as structured Markdown notes.
+
+**Each bookmark becomes a note** with YAML frontmatter:
+
+```yaml
+---
+tweet_id: "1933508347334177246"
+author: "alex_prompter"
+author_name: "Alex Prompter"
+date: 2025-06-13
+source: "https://x.com/alex_prompter/status/1933508347334177246"
+categories: ["AI & Agents", "PKM & Workflows"]
+tags:
+  - twitter/bookmark
+  - author/alex_prompter
+  - prompt-engineering
+  - llm
+  - automation
+  - category/ai-agents
+---
+```
+
+**Index notes** are generated automatically in a `_index/` subfolder:
+- One note per **category** — lists all bookmarks in that category as `[[wikilinks]]`
+- One note per **author** — lists every bookmark from that person
+
+This creates a dense backlink graph in Obsidian's graph view, where bookmarks cluster naturally by topic and author.
+
+**To set up:**
+1. Go to **Settings** → find the **Obsidian Export** section
+2. Enter the full path to your Obsidian vault folder (e.g. `/Users/you/Obsidian/Personal`)
+3. Click **Save**, then **Export to Obsidian**
+4. Open your vault in Obsidian — notes appear in a `Twitter Bookmarks/` folder
+
+Re-export anytime. By default, existing notes are skipped — enable **Overwrite** to replace them.
 
 ### ⌨️ Command Palette
 
@@ -241,6 +282,7 @@ All settings are manageable in the **Settings** page at `/settings` or via envir
 | API Base URL | `ANTHROPIC_BASE_URL` | Custom endpoint for proxies or local Anthropic-compatible models |
 | AI Model | Settings page only | Haiku 4.5 (default, fastest/cheapest), Sonnet 4.6, Opus 4.6 |
 | OpenAI Key | Settings page only | Alternative provider if no Anthropic key is set |
+| Obsidian Vault Path | Settings page only | Absolute path to your Obsidian vault folder for Markdown export |
 | Database | `DATABASE_URL` | SQLite file path (default: `file:./prisma/dev.db`) |
 
 ### Custom API Endpoint
@@ -266,6 +308,7 @@ siftly/
 │   │   │   └── [slug]/       # Individual category operations
 │   │   ├── categorize/       # 4-stage AI pipeline (start, status, stop)
 │   │   ├── export/           # CSV, JSON, ZIP export
+│   │   │   └── obsidian/     # Obsidian vault export endpoint
 │   │   ├── import/           # JSON file import with dedup + auto-pipeline trigger
 │   │   │   ├── bookmarklet/  # Bookmarklet-specific import endpoint
 │   │   │   └── twitter/      # Twitter-specific import endpoint
@@ -308,6 +351,7 @@ siftly/
 │   ├── rawjson-extractor.ts  # Entity extraction from raw tweet JSON
 │   ├── parser.ts             # Multi-format JSON parser
 │   ├── exporter.ts           # CSV, JSON, ZIP export
+│   ├── obsidian-exporter.ts  # Obsidian vault export (Markdown + YAML frontmatter + indexes)
 │   ├── types.ts              # Shared TypeScript types
 │   └── db.ts                 # Prisma client singleton
 │

--- a/app/api/export/obsidian/route.ts
+++ b/app/api/export/obsidian/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { exportToObsidian } from '@/lib/obsidian-exporter'
+import prisma from '@/lib/db'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: { category?: string; overwrite?: boolean } = {}
+  try {
+    body = await request.json()
+  } catch {
+    // body stays as defaults
+  }
+
+  const { category, overwrite = false } = body
+
+  const setting = await prisma.setting.findUnique({ where: { key: 'obsidianVaultPath' } })
+  if (!setting?.value) {
+    return NextResponse.json(
+      { error: 'Obsidian vault path not configured. Add it in Settings.' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const result = await exportToObsidian({
+      vaultPath: setting.value,
+      subfolder: 'Twitter Bookmarks',
+      overwrite,
+      categoryFilter: category,
+    })
+    return NextResponse.json(result)
+  } catch (err: unknown) {
+    console.error('Obsidian export error:', err)
+    return NextResponse.json(
+      { error: `Export failed: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -24,7 +24,7 @@ const ALLOWED_OPENAI_MODELS = [
 
 export async function GET(): Promise<NextResponse> {
   try {
-    const [anthropic, anthropicModel, provider, openai, openaiModel, xClientId, xClientSecret] = await Promise.all([
+    const [anthropic, anthropicModel, provider, openai, openaiModel, xClientId, xClientSecret, obsidianVaultPath] = await Promise.all([
       prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'anthropicModel' } }),
       prisma.setting.findUnique({ where: { key: 'aiProvider' } }),
@@ -32,6 +32,7 @@ export async function GET(): Promise<NextResponse> {
       prisma.setting.findUnique({ where: { key: 'openaiModel' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_id' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_secret' } }),
+      prisma.setting.findUnique({ where: { key: 'obsidianVaultPath' } }),
     ])
 
     return NextResponse.json({
@@ -45,6 +46,7 @@ export async function GET(): Promise<NextResponse> {
       xOAuthClientId: maskKey(xClientId?.value ?? null),
       xOAuthClientSecret: maskKey(xClientSecret?.value ?? null),
       hasXOAuth: !!xClientId?.value,
+      obsidianVaultPath: obsidianVaultPath?.value ?? null,
     })
   } catch (err) {
     console.error('Settings GET error:', err)
@@ -159,6 +161,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { status: 500 }
       )
     }
+  }
+
+  // Save Obsidian vault path if provided
+  if ('obsidianVaultPath' in body) {
+    const vaultPath = (body as { obsidianVaultPath?: string }).obsidianVaultPath
+    if (typeof vaultPath !== 'string' || vaultPath.trim() === '') {
+      return NextResponse.json({ error: 'Invalid obsidianVaultPath value' }, { status: 400 })
+    }
+    await prisma.setting.upsert({
+      where: { key: 'obsidianVaultPath' },
+      update: { value: vaultPath.trim() },
+      create: { key: 'obsidianVaultPath', value: vaultPath.trim() },
+    })
+    return NextResponse.json({ saved: true })
   }
 
   // Save X OAuth credentials if provided

--- a/app/api/settings/test/route.ts
+++ b/app/api/settings/test/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     let client
     try {
-      client = resolveOpenAIClient({ dbKey })
+      client = await resolveOpenAIClient({ dbKey })
     } catch {
       return NextResponse.json({ working: false, error: 'No OpenAI API key found. Add one in Settings or set up Codex CLI.' })
     }

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -92,7 +92,16 @@ const BOOKMARKLET_SCRIPT = `(async function(){
   function addTweet(t){
     if(!t||!t.rest_id||seen.has(t.rest_id))return;
     seen.add(t.rest_id);
-    var leg=t.legacy||{},usr=(t.core&&t.core.user_results&&t.core.user_results.result&&t.core.user_results.result.legacy)||{};
+    var leg=t.legacy||{};
+    var res=t.core&&t.core.user_results&&t.core.user_results.result;
+    var usrLeg=(res&&res.legacy)||{};
+    var usrCore=(res&&res.core)||{};
+    var usrAvatar=(res&&res.avatar)||{};
+    var usr={
+      name:usrCore.name||usrLeg.name||'Unknown',
+      screen_name:usrCore.screen_name||usrLeg.screen_name||'unknown',
+      profile_image_url_https:usrAvatar.image_url||usrLeg.profile_image_url_https||''
+    };
     var rawMedia=(leg.extended_entities&&leg.extended_entities.media)||(leg.entities&&leg.entities.media)||[];
     var media=rawMedia.map(function(m){
       var thumb=m.media_url_https||'';
@@ -191,11 +200,12 @@ const BOOKMARKLET_SCRIPT = `(async function(){
   document.body.appendChild(btn);
   document.body.appendChild(autoBtn);
   var origFetch=window.fetch;
+  function isRelevantUrl(u){return u.includes('/graphql/')&&(isLikes?u.toLowerCase().includes('like'):u.includes('Bookmark'));}
   window.fetch=async function(){
     var r=await origFetch.apply(this,arguments);
     try{
       var u=arguments[0] instanceof Request?arguments[0].url:String(arguments[0]);
-      if(u.includes('/graphql/')){var d=await r.clone().json();processData(d);}
+      if(isRelevantUrl(u)){var d=await r.clone().json();processData(d);}
     }catch(ex){}
     return r;
   };
@@ -203,7 +213,7 @@ const BOOKMARKLET_SCRIPT = `(async function(){
   XMLHttpRequest.prototype.open=function(){xhrUrls.set(this,String(arguments[1]||''));return origOpen.apply(this,arguments);};
   XMLHttpRequest.prototype.send=function(){
     var xhr=this,u=xhrUrls.get(xhr)||'';
-    if(u.includes('/graphql/')){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
+    if(isRelevantUrl(u)){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
     return origSend.apply(this,arguments);
   };
   showToast('\u2705 Active! Scroll your '+label+' \u2014 counter updates above.','#1e1b4b');
@@ -222,7 +232,16 @@ const CONSOLE_SCRIPT = `(async function() {
   function addTweet(t) {
     if (!t?.rest_id || seen.has(t.rest_id)) return;
     seen.add(t.rest_id);
-    const leg = t.legacy ?? {}, usr = t.core?.user_results?.result?.legacy ?? {};
+    const leg = t.legacy ?? {};
+    const res = t.core?.user_results?.result;
+    const usrLeg = res?.legacy ?? {};
+    const usrCore = res?.core ?? {};
+    const usrAvatar = res?.avatar ?? {};
+    const usr = {
+      name: usrCore.name ?? usrLeg.name ?? 'Unknown',
+      screen_name: usrCore.screen_name ?? usrLeg.screen_name ?? 'unknown',
+      profile_image_url_https: usrAvatar.image_url ?? usrLeg.profile_image_url_https ?? '',
+    };
     const media = (leg.extended_entities?.media ?? leg.entities?.media ?? []).map(m => {
       const thumb = m.media_url_https ?? '';
       if (m.type === 'video' || m.type === 'animated_gif') {
@@ -336,14 +355,13 @@ const CONSOLE_SCRIPT = `(async function() {
     autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
     runAutoScroll();
   };
-  document.body.appendChild(btn);
-  document.body.appendChild(autoBtn);
+  const isRelevantUrl = (u) => u.includes('/graphql/') && (isLikes ? u.toLowerCase().includes('like') : u.includes('Bookmark'));
   const origFetch = window.fetch;
   window.fetch = async function(...args) {
     const r = await origFetch.apply(this, args);
     try {
       const u = args[0] instanceof Request ? args[0].url : String(args[0]);
-      if (u.includes('/graphql/')) {
+      if (isRelevantUrl(u)) {
         const d = await r.clone().json();
         processData(d);
       }
@@ -359,13 +377,15 @@ const CONSOLE_SCRIPT = `(async function() {
   };
   XMLHttpRequest.prototype.send = function(...args) {
     const xhr = this, u = xhrUrls.get(xhr) ?? '';
-    if (u.includes('/graphql/')) {
+    if (isRelevantUrl(u)) {
       xhr.addEventListener('load', function() {
         try { processData(JSON.parse(xhr.responseText)); } catch(e) {}
       });
     }
     return origSend.apply(this, args);
   };
+  document.body.appendChild(btn);
+  document.body.appendChild(autoBtn);
   console.log(\`✅ Script active. Scroll through your \${label}, then click the purple button.\`);
 })();`
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -20,6 +20,8 @@ import {
   Terminal,
   Loader2,
   X,
+  BookOpen,
+  FolderOpen,
 } from 'lucide-react'
 
 const ANTHROPIC_MODELS = [
@@ -655,7 +657,164 @@ function ExportButton({
   )
 }
 
-function DataSection() {
+interface ObsidianResult {
+  written: number
+  skipped: number
+  errors: Array<{ tweetId: string; error: string }>
+  indexesWritten: number
+}
+
+function ObsidianExportBlock({ onToast }: { onToast: (t: Toast) => void }) {
+  const [vaultPath, setVaultPath] = useState('')
+  const [savedPath, setSavedPath] = useState<string | null>(null)
+  const [savingPath, setSavingPath] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const [result, setResult] = useState<ObsidianResult | null>(null)
+  const [overwrite, setOverwrite] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((d: Record<string, unknown>) => {
+        if (d.obsidianVaultPath) setSavedPath(d.obsidianVaultPath as string)
+      })
+      .catch(() => {})
+  }, [])
+
+  async function handleSavePath() {
+    if (!vaultPath.trim()) {
+      onToast({ type: 'error', message: 'Enter a vault path first' })
+      return
+    }
+    setSavingPath(true)
+    try {
+      const res = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ obsidianVaultPath: vaultPath.trim() }),
+      })
+      if (!res.ok) {
+        const data = await res.json() as { error?: string }
+        throw new Error(data.error ?? 'Failed to save')
+      }
+      setSavedPath(vaultPath.trim())
+      setVaultPath('')
+      onToast({ type: 'success', message: 'Vault path saved' })
+    } catch (err) {
+      onToast({ type: 'error', message: err instanceof Error ? err.message : 'Failed to save path' })
+    } finally {
+      setSavingPath(false)
+    }
+  }
+
+  async function handleExport() {
+    setExporting(true)
+    setResult(null)
+    try {
+      const res = await fetch('/api/export/obsidian', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ overwrite }),
+      })
+      const data = await res.json() as ObsidianResult & { error?: string }
+      if (!res.ok) throw new Error(data.error ?? 'Export failed')
+      setResult(data)
+      onToast({ type: 'success', message: `${data.written} notes written to vault` })
+    } catch (err) {
+      onToast({ type: 'error', message: err instanceof Error ? err.message : 'Export failed' })
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <div className="mt-5 pt-5 border-t border-zinc-800">
+      <div className="flex items-center gap-2 mb-3">
+        <BookOpen size={14} className="text-indigo-400 shrink-0" />
+        <p className="text-sm font-medium text-zinc-300">Export to Obsidian</p>
+      </div>
+
+      {/* Vault path row */}
+      <div className="space-y-2 mb-3">
+        <div className="flex gap-2.5">
+          <div className="relative flex-1">
+            <FolderOpen size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 pointer-events-none" />
+            <input
+              type="text"
+              value={vaultPath}
+              onChange={(e) => setVaultPath(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && void handleSavePath()}
+              placeholder={savedPath ?? 'C:\\Users\\you\\Obsidian\\MyVault'}
+              className="w-full pl-8 pr-3.5 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-100 placeholder:text-zinc-600 text-sm focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500/20 transition-all duration-200 font-mono"
+            />
+          </div>
+          <button
+            onClick={() => void handleSavePath()}
+            disabled={savingPath}
+            className="px-4 py-2.5 rounded-xl bg-zinc-700 hover:bg-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed text-zinc-200 text-sm font-medium transition-colors shrink-0"
+          >
+            {savingPath ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+        {savedPath && (
+          <p className="text-xs text-zinc-500 flex items-center gap-1.5">
+            <Check size={11} className="text-emerald-400 shrink-0" />
+            <span className="font-mono text-zinc-400 truncate">{savedPath}</span>
+          </p>
+        )}
+      </div>
+
+      {/* Overwrite toggle + export button */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => void handleExport()}
+          disabled={exporting || !savedPath}
+          className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors shrink-0"
+        >
+          {exporting
+            ? <><Loader2 size={14} className="animate-spin" /> Exporting…</>
+            : <><BookOpen size={14} /> Export to Obsidian</>
+          }
+        </button>
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={overwrite}
+            onChange={(e) => setOverwrite(e.target.checked)}
+            className="rounded border-zinc-600 bg-zinc-800 text-indigo-500 focus:ring-indigo-500/20"
+          />
+          <span className="text-xs text-zinc-500">Overwrite existing notes</span>
+        </label>
+      </div>
+
+      {/* Result summary */}
+      {result && (
+        <div className="mt-3 flex flex-wrap gap-3 text-xs">
+          <span className="flex items-center gap-1.5 text-emerald-400 bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-1 rounded-lg">
+            <Check size={11} /> {result.written} written
+          </span>
+          <span className="text-zinc-500 bg-zinc-800 border border-zinc-700 px-2.5 py-1 rounded-lg">
+            {result.skipped} skipped
+          </span>
+          <span className="text-zinc-500 bg-zinc-800 border border-zinc-700 px-2.5 py-1 rounded-lg">
+            {result.indexesWritten} indexes
+          </span>
+          {result.errors.length > 0 && (
+            <span className="flex items-center gap-1.5 text-red-400 bg-red-500/10 border border-red-500/20 px-2.5 py-1 rounded-lg">
+              <AlertCircle size={11} /> {result.errors.length} errors
+            </span>
+          )}
+        </div>
+      )}
+
+      <p className="text-xs text-zinc-600 mt-3">
+        Notes are written to a <span className="font-mono text-zinc-500">Twitter Bookmarks/</span> subfolder inside your vault. Index notes linking by author and category are created automatically in <span className="font-mono text-zinc-500">_index/</span>.
+      </p>
+    </div>
+  )
+}
+
+function DataSection({ onToast }: { onToast: (t: Toast) => void }) {
   return (
     <Section
       icon={Database}
@@ -674,6 +833,7 @@ function DataSection() {
           description="Full data with all fields"
         />
       </div>
+      <ObsidianExportBlock onToast={onToast} />
     </Section>
   )
 }
@@ -1006,7 +1166,7 @@ export default function SettingsPage() {
       <div className="space-y-4">
         <ApiKeySection onToast={showToast} />
         <XOAuthSection onToast={showToast} />
-        <DataSection />
+        <DataSection onToast={showToast} />
         <DangerZoneSection onToast={showToast} />
         <AboutSection />
       </div>

--- a/lib/ai-client.ts
+++ b/lib/ai-client.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk'
-import OpenAI from 'openai'
+import type OpenAI from 'openai'
 import { resolveAnthropicClient } from './claude-cli-auth'
 import { resolveOpenAIClient } from './openai-auth'
 import { getProvider } from './settings'
@@ -106,7 +106,7 @@ export async function resolveAIClient(options: {
   const provider = await getProvider()
 
   if (provider === 'openai') {
-    const client = resolveOpenAIClient(options)
+    const client = await resolveOpenAIClient(options)
     return new OpenAIAIClient(client)
   }
 

--- a/lib/obsidian-exporter.ts
+++ b/lib/obsidian-exporter.ts
@@ -1,0 +1,252 @@
+import fs from 'fs/promises'
+import path from 'path'
+import prisma from '@/lib/db'
+
+export interface ObsidianExportResult {
+  written: number
+  skipped: number
+  errors: Array<{ tweetId: string; error: string }>
+  indexesWritten: number
+}
+
+interface ObsidianExportOptions {
+  vaultPath: string
+  subfolder?: string
+  overwrite?: boolean
+  categoryFilter?: string
+}
+
+interface MediaItemRow {
+  type: string
+  url: string
+  thumbnailUrl: string | null
+}
+
+interface CategoryJoin {
+  category: {
+    name: string
+    slug: string
+    color: string
+  }
+}
+
+interface BookmarkRow {
+  id: string
+  tweetId: string
+  text: string
+  authorHandle: string
+  authorName: string
+  tweetCreatedAt: Date | null
+  importedAt: Date
+  semanticTags: string | null
+  entities: string | null
+  mediaItems: MediaItemRow[]
+  categories: CategoryJoin[]
+}
+
+function sanitizeTag(tag: string): string {
+  return tag
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9\-_/]/g, '')
+    .replace(/-+/g, '-')
+    .trim()
+}
+
+function sanitizeFilename(str: string): string {
+  return str.replace(/[<>:"/\\|?*\n\r]/g, '').trim()
+}
+
+function noteFilename(bookmark: BookmarkRow): string {
+  const date = bookmark.tweetCreatedAt
+    ? new Date(bookmark.tweetCreatedAt).toISOString().split('T')[0]
+    : 'unknown'
+  const author = sanitizeFilename(bookmark.authorHandle || 'unknown')
+  return `${date} - @${author} - ${bookmark.tweetId}.md`
+}
+
+function buildNoteMarkdown(bookmark: BookmarkRow): string {
+  const tags: string[] = ['twitter/bookmark']
+
+  if (bookmark.authorHandle) {
+    tags.push(`author/${sanitizeTag(bookmark.authorHandle)}`)
+  }
+
+  let semanticTags: string[] = []
+  try { semanticTags = JSON.parse(bookmark.semanticTags || '[]') } catch {}
+  semanticTags.forEach(t => { const c = sanitizeTag(t); if (c) tags.push(c) })
+
+  const categories = bookmark.categories.map((bc) => bc.category.name)
+  categories.forEach((c) => tags.push(`category/${sanitizeTag(c)}`))
+
+  const date = bookmark.tweetCreatedAt
+    ? new Date(bookmark.tweetCreatedAt).toISOString().split('T')[0]
+    : null
+  const sourceUrl = `https://x.com/${bookmark.authorHandle}/status/${bookmark.tweetId}`
+
+  const frontmatter = [
+    '---',
+    `tweet_id: "${bookmark.tweetId}"`,
+    `author: "${bookmark.authorHandle || ''}"`,
+    `author_name: "${(bookmark.authorName || '').replace(/"/g, "'")}"`,
+    date ? `date: ${date}` : null,
+    `source: "${sourceUrl}"`,
+    `categories: [${categories.map((c) => `"${c}"`).join(', ')}]`,
+    `tags:`,
+    ...tags.map(t => `  - ${t}`),
+    '---',
+  ].filter(Boolean).join('\n')
+
+  const lines: string[] = [frontmatter, '', bookmark.text || '']
+
+  if (bookmark.mediaItems.length > 0) {
+    lines.push('', '## Media', '')
+    for (const item of bookmark.mediaItems) {
+      if (item.type === 'photo') {
+        lines.push(`![](${item.url})`)
+      } else {
+        lines.push(`[${item.type.toUpperCase()}](${item.url})`)
+      }
+    }
+  }
+
+  lines.push('', '## Source', '', `[View on X](${sourceUrl})`)
+  return lines.join('\n')
+}
+
+// Build a category index note with wikilinks to every bookmark in that category
+function buildCategoryIndex(
+  categoryName: string,
+  bookmarks: BookmarkRow[]
+): string {
+  const tag = sanitizeTag(categoryName)
+  const links = bookmarks
+    .map(b => `- [[${noteFilename(b).replace(/\.md$/, '')}]]`)
+    .join('\n')
+
+  return [
+    '---',
+    `type: index`,
+    `category: "${categoryName}"`,
+    `tags:`,
+    `  - index/category`,
+    `  - category/${tag}`,
+    '---',
+    '',
+    `# ${categoryName}`,
+    '',
+    `${bookmarks.length} bookmarks`,
+    '',
+    '## Bookmarks',
+    '',
+    links,
+  ].join('\n')
+}
+
+// Build an author index note with wikilinks to every bookmark from that author
+function buildAuthorIndex(
+  handle: string,
+  displayName: string,
+  bookmarks: BookmarkRow[]
+): string {
+  const links = bookmarks
+    .map(b => `- [[${noteFilename(b).replace(/\.md$/, '')}]]`)
+    .join('\n')
+
+  return [
+    '---',
+    `type: index`,
+    `author: "${handle}"`,
+    `author_name: "${displayName.replace(/"/g, "'")}"`,
+    `tags:`,
+    `  - index/author`,
+    `  - author/${sanitizeTag(handle)}`,
+    '---',
+    '',
+    `# @${handle}`,
+    '',
+    `${bookmarks.length} bookmarks`,
+    '',
+    '## Bookmarks',
+    '',
+    links,
+  ].join('\n')
+}
+
+export async function exportToObsidian(options: ObsidianExportOptions): Promise<ObsidianExportResult> {
+  const { vaultPath, subfolder = 'Twitter Bookmarks', overwrite = false, categoryFilter } = options
+
+  const notesDir = path.join(vaultPath, subfolder)
+  const indexDir = path.join(vaultPath, subfolder, '_index')
+  await fs.mkdir(notesDir, { recursive: true })
+  await fs.mkdir(indexDir, { recursive: true })
+
+  const where = categoryFilter
+    ? { categories: { some: { category: { slug: categoryFilter } } } }
+    : {}
+
+  const bookmarks = await prisma.bookmark.findMany({
+    where,
+    include: {
+      mediaItems: true,
+      categories: { include: { category: true } },
+    },
+    orderBy: { tweetCreatedAt: 'desc' },
+  }) as BookmarkRow[]
+
+  const result: ObsidianExportResult = { written: 0, skipped: 0, errors: [], indexesWritten: 0 }
+
+  // Write individual bookmark notes
+  for (const bookmark of bookmarks) {
+    const filename = noteFilename(bookmark)
+    const filePath = path.join(notesDir, filename)
+
+    if (!overwrite) {
+      try { await fs.access(filePath); result.skipped++; continue } catch {}
+    }
+
+    try {
+      await fs.writeFile(filePath, buildNoteMarkdown(bookmark), 'utf-8')
+      result.written++
+    } catch (err: unknown) {
+      result.errors.push({
+        tweetId: bookmark.tweetId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  // Build and write category index notes
+  const byCategory = new Map<string, BookmarkRow[]>()
+  for (const bookmark of bookmarks) {
+    for (const bc of bookmark.categories) {
+      const name = bc.category.name
+      if (!byCategory.has(name)) byCategory.set(name, [])
+      byCategory.get(name)!.push(bookmark)
+    }
+  }
+  for (const [categoryName, categoryBookmarks] of byCategory) {
+    const filename = `_${sanitizeFilename(categoryName)}.md`
+    const filePath = path.join(indexDir, filename)
+    await fs.writeFile(filePath, buildCategoryIndex(categoryName, categoryBookmarks), 'utf-8')
+    result.indexesWritten++
+  }
+
+  // Build and write author index notes
+  const byAuthor = new Map<string, { displayName: string; bookmarks: BookmarkRow[] }>()
+  for (const bookmark of bookmarks) {
+    const handle = bookmark.authorHandle || 'unknown'
+    if (!byAuthor.has(handle)) {
+      byAuthor.set(handle, { displayName: bookmark.authorName || handle, bookmarks: [] })
+    }
+    byAuthor.get(handle)!.bookmarks.push(bookmark)
+  }
+  for (const [handle, { displayName, bookmarks: authorBookmarks }] of byAuthor) {
+    const filename = `@${sanitizeFilename(handle)}.md`
+    const filePath = path.join(indexDir, filename)
+    await fs.writeFile(filePath, buildAuthorIndex(handle, displayName, authorBookmarks), 'utf-8')
+    result.indexesWritten++
+  }
+
+  return result
+}

--- a/lib/openai-auth.ts
+++ b/lib/openai-auth.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import OpenAI from 'openai'
+import type OpenAI from 'openai'
 
 interface CodexAuth {
   auth_mode?: string
@@ -104,17 +104,19 @@ export function getCodexCliAuthStatus(): {
   return { available: true, authMode: auth.auth_mode, planType }
 }
 
-function createCodexOpenAIClient(baseURL?: string): OpenAI | null {
+async function createCodexOpenAIClient(baseURL?: string): Promise<OpenAI | null> {
   const apiKey = getCodexApiKey()
   if (!apiKey) return null
+  const { default: OpenAI } = await import('openai')
   return new OpenAI({ apiKey, ...(baseURL ? { baseURL } : {}) })
 }
 
-export function resolveOpenAIClient(options: {
+export async function resolveOpenAIClient(options: {
   overrideKey?: string
   dbKey?: string
   baseURL?: string
-} = {}): OpenAI {
+} = {}): Promise<OpenAI> {
+  const { default: OpenAI } = await import('openai')
   const baseURL = options.baseURL ?? process.env.OPENAI_BASE_URL
 
   if (options.overrideKey?.trim()) {
@@ -125,7 +127,7 @@ export function resolveOpenAIClient(options: {
     return new OpenAI({ apiKey: options.dbKey.trim(), ...(baseURL ? { baseURL } : {}) })
   }
 
-  const cliClient = createCodexOpenAIClient(baseURL)
+  const cliClient = await createCodexOpenAIClient(baseURL)
   if (cliClient) return cliClient
 
   const envKey = process.env.OPENAI_API_KEY?.trim()


### PR DESCRIPTION
## Summary
This feature enables users to export their Twitter bookmarks directly to their Obsidian vault, improving integration with note-taking workflows.

## Changes
- Add a new API route for exporting bookmarks to Obsidian, including error handling and configuration checks.
- Enhance settings API to allow saving and retrieving the Obsidian vault path.
- Introduce UI button component in settings page for managing Obsidian export
- Implement logic for exporting bookmarks with optional category filtering and overwrite capabilities.
- Create utility functions for generating markdown files and index notes for bookmarks in the Obsidian format.

## Related Issues
Allows lazy load of the Open-AI dependency, so it's only loaded if called by user config

## Checklist
- [x] Tested locally
- [x] `npx tsc --noEmit` passes
- [x] No new warnings
