### PR TITLE
Add pi-ai provider to support local LLMs and auth-based models

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,97 @@ New accounts include $5 free credit — enough for thousands of bookmarks at Hai
 
 ---
 
+## pi-ai (Multi-model provider)
+
+Siftly supports a third AI provider option: **`pi-ai`**.
+
+This uses [`@mariozechner/pi-ai`](https://github.com/badlogic/pi-mono/tree/main/packages/ai) to talk to many providers and models, including **OpenAI-compatible endpoints**.
+
+### Configure in the UI (recommended)
+
+1. Go to **Settings → AI Provider**
+2. Select **pi-ai (Multi-model)**
+3. Fill in:
+
+| Field | Meaning |
+|------:|---------|
+| `pi-ai API Key` | The provider API key (if required) |
+| `Provider ID` | Provider identifier supported by pi-ai (e.g. `openai`, `openrouter`, `groq`, `anthropic`, `google`, …) |
+| `Model ID` | Model identifier for that provider |
+| `Base URL` (optional) | For OpenAI-compatible servers (Ollama, vLLM, LM Studio, LiteLLM, custom gateways) |
+| `Headers JSON` (optional) | Extra headers added to requests (JSON object) |
+| `Compat JSON` (optional) | Compatibility tweaks (JSON object) |
+
+Then click **Save pi-ai config** and use the **Test** button to verify connectivity.
+
+### Sample configuration (LM Studio local server on M4 pro 48GB)
+
+- Provider ID: `openai`
+- Model ID: `zai-org/glm-4.6v-flash`
+- Base URL: `http://127.0.0.1:1234/v1`
+
+### Environment variable overrides
+
+You can also override pi-ai settings via env vars (useful for Docker / deployments):
+
+```bash
+PI_AI_API_KEY=...
+PI_AI_BASE_URL=...
+PI_AI_HEADERS='{"Authorization":"Bearer ..."}'
+PI_AI_COMPAT='{}'
+
+# aliases also supported
+PIAI_API_KEY=...
+PIAI_BASE_URL=...
+```
+
+### Example presets
+
+#### OpenAI
+
+- Provider ID: `openai`
+- Model ID: `gpt-4o-mini`
+- Base URL: *(empty)*
+
+#### OpenRouter
+
+- Provider ID: `openrouter`
+- Model ID: `openai/gpt-4o-mini` *(or any OpenRouter model slug)*
+- Base URL: *(empty)*
+- Headers JSON (optional):
+
+```json
+{ "HTTP-Referer": "http://localhost:3000", "X-Title": "Siftly" }
+```
+
+#### Groq
+
+- Provider ID: `groq`
+- Model ID: `llama-3.1-70b-versatile`
+- Base URL: *(empty)*
+
+#### Local OpenAI-compatible (Ollama)
+
+This works with any server exposing an OpenAI-compatible API.
+
+- Provider ID: `openai`
+- Model ID: `llama3.1`
+- Base URL: `http://localhost:11434/v1`
+
+If your endpoint does not require a key, you can leave the API key blank.
+
+### Smoke test
+
+After configuring `pi-ai` in Settings:
+
+1. Click **Test** next to your pi-ai key.
+2. Run the pipeline on a small import to confirm:
+   - Vision analysis
+   - Semantic tags
+   - Categorization
+
+---
+
 ## Importing Your Bookmarks
 
 Siftly has **built-in import tools** — no browser extensions required. Go to the **Import** page and choose either method:

--- a/app/api/analyze/images/route.ts
+++ b/app/api/analyze/images/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const provider = await getProvider()
-  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const keyName = provider === 'openai' ? 'openaiApiKey' : provider === 'pi-ai' ? 'piAiApiKey' : 'anthropicApiKey'
   const setting = await prisma.setting.findUnique({ where: { key: keyName } })
   const dbKey = setting?.value?.trim()
 

--- a/app/api/categorize/route.ts
+++ b/app/api/categorize/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   if (apiKey && typeof apiKey === 'string' && apiKey.trim() !== '') {
     const currentProvider = await getProvider()
-    const keySlot = currentProvider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+    const keySlot = currentProvider === 'openai' ? 'openaiApiKey' : currentProvider === 'pi-ai' ? 'piAiApiKey' : 'anthropicApiKey'
     await prisma.setting.upsert({
       where: { key: keySlot },
       update: { value: apiKey.trim() },
@@ -145,7 +145,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   })
 
   const provider = await getProvider()
-  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const keyName = provider === 'openai' ? 'openaiApiKey' : provider === 'pi-ai' ? 'piAiApiKey' : 'anthropicApiKey'
   const dbApiKey =
     (await prisma.setting.findUnique({ where: { key: keyName } }))?.value?.trim() || ''
 

--- a/app/api/search/ai/route.ts
+++ b/app/api/search/ai/route.ts
@@ -32,12 +32,12 @@ let _categoriesCacheExpiry = 0
 async function getDbApiKey(): Promise<string> {
   if (_apiKey !== null && Date.now() < _apiKeyExpiry) return _apiKey
   const provider = await getProvider()
-  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const keyName = provider === 'openai' ? 'openaiApiKey' : provider === 'pi-ai' ? 'piAiApiKey' : 'anthropicApiKey'
   const setting = await prisma.setting.findUnique({ where: { key: keyName } })
   const fromDb = setting?.value?.trim() ?? ''
   _apiKey = fromDb
   _apiKeyExpiry = Date.now() + 60_000
-  return _apiKey
+  return fromDb
 }
 async function getAllCategories() {
   if (_categoriesCache && Date.now() < _categoriesCacheExpiry) return _categoriesCache

--- a/app/api/settings/cli-status/route.ts
+++ b/app/api/settings/cli-status/route.ts
@@ -10,7 +10,11 @@ export async function GET(): Promise<NextResponse> {
   // Read provider directly from DB (not cached) — this endpoint is called
   // right after the user toggles the provider, so it must be fresh.
   const providerSetting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
-  const provider = providerSetting?.value === 'openai' ? 'openai' : 'anthropic'
+  const provider = providerSetting?.value === 'openai'
+    ? 'openai'
+    : providerSetting?.value === 'pi-ai'
+    ? 'pi-ai'
+    : 'anthropic'
 
   // Only check CLI subprocess availability if OAuth credentials exist
   const cliDirectAvailable = oauthStatus.available && !oauthStatus.expired

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -24,12 +24,18 @@ const ALLOWED_OPENAI_MODELS = [
 
 export async function GET(): Promise<NextResponse> {
   try {
-    const [anthropic, anthropicModel, provider, openai, openaiModel, xClientId, xClientSecret] = await Promise.all([
+    const [anthropic, anthropicModel, provider, openai, openaiModel, piAiKey, piAiProvider, piAiModel, piAiBaseUrl, piAiHeaders, piAiCompat, xClientId, xClientSecret] = await Promise.all([
       prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'anthropicModel' } }),
       prisma.setting.findUnique({ where: { key: 'aiProvider' } }),
       prisma.setting.findUnique({ where: { key: 'openaiApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'openaiModel' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiApiKey' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiProvider' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiModel' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiBaseUrl' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiHeaders' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiCompat' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_id' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_secret' } }),
     ])
@@ -42,6 +48,13 @@ export async function GET(): Promise<NextResponse> {
       openaiApiKey: maskKey(openai?.value ?? null),
       hasOpenaiKey: openai !== null,
       openaiModel: openaiModel?.value ?? 'gpt-4.1-mini',
+      piAiApiKey: maskKey(piAiKey?.value ?? null),
+      hasPiAiKey: piAiKey !== null,
+      piAiProvider: piAiProvider?.value ?? 'openai',
+      piAiModel: piAiModel?.value ?? 'gpt-4o-mini',
+      piAiBaseUrl: piAiBaseUrl?.value ?? null,
+      piAiHeaders: piAiHeaders?.value ?? null,
+      piAiCompat: piAiCompat?.value ?? null,
       xOAuthClientId: maskKey(xClientId?.value ?? null),
       xOAuthClientSecret: maskKey(xClientSecret?.value ?? null),
       hasXOAuth: !!xClientId?.value,
@@ -62,6 +75,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     provider?: string
     openaiApiKey?: string
     openaiModel?: string
+    piAiApiKey?: string
+    piAiProvider?: string
+    piAiModel?: string
+    piAiBaseUrl?: string
+    piAiHeaders?: string
+    piAiCompat?: string
     xOAuthClientId?: string
     xOAuthClientSecret?: string
   } = {}
@@ -75,7 +94,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Save provider if provided
   if (provider !== undefined) {
-    if (provider !== 'anthropic' && provider !== 'openai') {
+    if (provider !== 'anthropic' && provider !== 'openai' && provider !== 'pi-ai') {
       return NextResponse.json({ error: 'Invalid provider' }, { status: 400 })
     }
     await prisma.setting.upsert({
@@ -83,6 +102,91 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       update: { value: provider },
       create: { key: 'aiProvider', value: provider },
     })
+    invalidateSettingsCache()
+    return NextResponse.json({ saved: true })
+  }
+
+  // Save pi-ai fields if provided
+  const { piAiApiKey, piAiProvider, piAiModel, piAiBaseUrl, piAiHeaders, piAiCompat } = body
+
+  const hasAnyPiAiField =
+    piAiApiKey !== undefined ||
+    piAiProvider !== undefined ||
+    piAiModel !== undefined ||
+    piAiBaseUrl !== undefined ||
+    piAiHeaders !== undefined ||
+    piAiCompat !== undefined
+
+  if (hasAnyPiAiField) {
+    if (piAiApiKey !== undefined) {
+      if (typeof piAiApiKey !== 'string' || piAiApiKey.trim() === '') {
+        return NextResponse.json({ error: 'Invalid piAiApiKey value' }, { status: 400 })
+      }
+    }
+    if (piAiProvider !== undefined) {
+      if (typeof piAiProvider !== 'string' || piAiProvider.trim() === '') {
+        return NextResponse.json({ error: 'Invalid piAiProvider value' }, { status: 400 })
+      }
+    }
+    if (piAiModel !== undefined) {
+      if (typeof piAiModel !== 'string' || piAiModel.trim() === '') {
+        return NextResponse.json({ error: 'Invalid piAiModel value' }, { status: 400 })
+      }
+    }
+    if (piAiBaseUrl !== undefined) {
+      if (typeof piAiBaseUrl !== 'string') {
+        return NextResponse.json({ error: 'Invalid piAiBaseUrl value' }, { status: 400 })
+      }
+    }
+    if (piAiHeaders !== undefined) {
+      if (typeof piAiHeaders !== 'string') {
+        return NextResponse.json({ error: 'Invalid piAiHeaders value' }, { status: 400 })
+      }
+      const trimmed = piAiHeaders.trim()
+      if (trimmed) {
+        try {
+          const parsed = JSON.parse(trimmed) as unknown
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return NextResponse.json({ error: 'piAiHeaders must be a JSON object' }, { status: 400 })
+          }
+        } catch {
+          return NextResponse.json({ error: 'piAiHeaders must be valid JSON' }, { status: 400 })
+        }
+      }
+    }
+    if (piAiCompat !== undefined) {
+      if (typeof piAiCompat !== 'string') {
+        return NextResponse.json({ error: 'Invalid piAiCompat value' }, { status: 400 })
+      }
+      const trimmed = piAiCompat.trim()
+      if (trimmed) {
+        try {
+          const parsed = JSON.parse(trimmed) as unknown
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return NextResponse.json({ error: 'piAiCompat must be a JSON object' }, { status: 400 })
+          }
+        } catch {
+          return NextResponse.json({ error: 'piAiCompat must be valid JSON' }, { status: 400 })
+        }
+      }
+    }
+
+    const toUpsert: { key: string; value: string }[] = []
+    if (piAiApiKey !== undefined) toUpsert.push({ key: 'piAiApiKey', value: piAiApiKey.trim() })
+    if (piAiProvider !== undefined) toUpsert.push({ key: 'piAiProvider', value: piAiProvider.trim() })
+    if (piAiModel !== undefined) toUpsert.push({ key: 'piAiModel', value: piAiModel.trim() })
+    if (piAiBaseUrl !== undefined) toUpsert.push({ key: 'piAiBaseUrl', value: piAiBaseUrl.trim() })
+    if (piAiHeaders !== undefined) toUpsert.push({ key: 'piAiHeaders', value: piAiHeaders.trim() })
+    if (piAiCompat !== undefined) toUpsert.push({ key: 'piAiCompat', value: piAiCompat.trim() })
+
+    for (const { key, value } of toUpsert) {
+      await prisma.setting.upsert({
+        where: { key },
+        update: { value },
+        create: { key, value },
+      })
+    }
+
     invalidateSettingsCache()
     return NextResponse.json({ saved: true })
   }
@@ -198,7 +302,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const allowed = ['anthropicApiKey', 'openaiApiKey', 'x_oauth_client_id', 'x_oauth_client_secret']
+  const allowed = ['anthropicApiKey', 'openaiApiKey', 'piAiApiKey', 'piAiProvider', 'piAiModel', 'piAiBaseUrl', 'piAiHeaders', 'piAiCompat', 'x_oauth_client_id', 'x_oauth_client_secret']
   if (!body.key || !allowed.includes(body.key)) {
     return NextResponse.json({ error: 'Invalid key' }, { status: 400 })
   }

--- a/app/api/settings/test/route.ts
+++ b/app/api/settings/test/route.ts
@@ -2,9 +2,19 @@ import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db'
 import { resolveAnthropicClient, getCliAuthStatus } from '@/lib/claude-cli-auth'
 import { resolveOpenAIClient } from '@/lib/openai-auth'
+import { complete, getModel, type Model } from '@mariozechner/pi-ai'
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  let body: { provider?: string } = {}
+  let body: {
+    provider?: string
+    message?: string
+    piAiApiKey?: string
+    piAiProvider?: string
+    piAiModel?: string
+    piAiBaseUrl?: string
+    piAiHeaders?: string
+    piAiCompat?: string
+  } = {}
   try {
     const text = await request.text()
     if (text.trim()) body = JSON.parse(text)
@@ -13,6 +23,113 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const provider = body.provider ?? 'anthropic'
+  const message = typeof body.message === 'string' && body.message.trim() ? body.message.trim() : 'hi'
+
+  if (provider === 'pi-ai') {
+    const [piAiKey, piAiProvider, piAiModel, piAiBaseUrl, piAiHeaders, piAiCompat] = await Promise.all([
+      prisma.setting.findUnique({ where: { key: 'piAiApiKey' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiProvider' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiModel' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiBaseUrl' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiHeaders' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiCompat' } }),
+    ])
+
+    const providerId = (
+      (typeof body.piAiProvider === 'string' && body.piAiProvider.trim() ? body.piAiProvider : piAiProvider?.value ?? 'openai')
+    ).trim()
+    const modelId = (
+      (typeof body.piAiModel === 'string' && body.piAiModel.trim() ? body.piAiModel : piAiModel?.value ?? 'gpt-4o-mini')
+    ).trim()
+    const baseUrlRaw =
+      typeof body.piAiBaseUrl === 'string' && body.piAiBaseUrl.trim()
+        ? body.piAiBaseUrl
+        : (piAiBaseUrl?.value ?? '')
+    const baseUrl = baseUrlRaw.trim() || null
+
+    const safeJsonParseObject = (raw: string | null | undefined): Record<string, unknown> | null => {
+      if (!raw?.trim()) return null
+      try {
+        const parsed = JSON.parse(raw) as unknown
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+        return null
+      } catch {
+        return null
+      }
+    }
+
+    const headers = safeJsonParseObject(
+      typeof body.piAiHeaders === 'string' ? body.piAiHeaders : piAiHeaders?.value ?? null,
+    ) as Record<string, string> | null
+    const compat = safeJsonParseObject(
+      typeof body.piAiCompat === 'string' ? body.piAiCompat : piAiCompat?.value ?? null,
+    )
+
+    let model: Model<any>
+    if (!baseUrl && !headers && !compat) {
+      model = getModel(providerId as any, modelId as any) as any
+    } else {
+      model = {
+        id: modelId,
+        name: modelId,
+        api: 'openai-completions',
+        provider: 'openai',
+        baseUrl: baseUrl || undefined,
+        reasoning: false,
+        input: ['text', 'image'],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+        ...(headers ? { headers } : {}),
+        ...(compat ? { compat: compat as any } : {}),
+      } as any
+    }
+
+    const apiKeyRaw =
+      typeof body.piAiApiKey === 'string' && body.piAiApiKey.trim()
+        ? body.piAiApiKey
+        : (piAiKey?.value ?? '')
+    const apiKey = apiKeyRaw.trim() || null
+    if (!apiKey && !baseUrl) {
+      return NextResponse.json(
+        { working: false, error: 'No pi-ai API key found and no Base URL configured.' },
+        { status: 400 },
+      )
+    }
+
+    const effectiveApiKey = apiKey || (baseUrl ? 'local' : null)
+
+    try {
+      const response = await complete(
+        model,
+        {
+          messages: [{ role: 'user', content: [{ type: 'text', text: message }] }],
+        } as any,
+        {
+          apiKey: effectiveApiKey || undefined,
+          maxTokens: 5,
+        } as any,
+      )
+
+      const hasAnyText = Array.isArray((response as any).content)
+        ? (response as any).content.some((b: any) => b?.type === 'text' && typeof b.text === 'string')
+        : false
+
+      if (!hasAnyText) {
+        return NextResponse.json({ working: false, error: 'No text content returned from model.' })
+      }
+
+      return NextResponse.json({ working: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      const friendly = msg.includes('401') || msg.includes('invalid_api_key')
+        ? 'Invalid API key'
+        : msg.includes('403')
+        ? 'Key does not have permission'
+        : msg.slice(0, 120)
+      return NextResponse.json({ working: false, error: friendly })
+    }
+  }
 
   if (provider === 'anthropic') {
     const setting = await prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } })

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, type ChangeEvent } from 'react'
 import {
   Eye,
   EyeOff,
@@ -106,7 +106,7 @@ function ApiKeyField({
 }: {
   label: string
   placeholder: string
-  fieldKey: 'anthropicApiKey' | 'openaiApiKey'
+  fieldKey: 'anthropicApiKey' | 'openaiApiKey' | 'piAiApiKey'
   hint: string
   docHref: string
   onToast: (t: Toast) => void
@@ -125,7 +125,11 @@ function ApiKeyField({
     fetch('/api/settings')
       .then((r) => r.json())
       .then((d: Record<string, unknown>) => {
-        const hasKeyField = fieldKey === 'openaiApiKey' ? 'hasOpenaiKey' : 'hasAnthropicKey'
+        const hasKeyField = fieldKey === 'openaiApiKey'
+          ? 'hasOpenaiKey'
+          : fieldKey === 'piAiApiKey'
+          ? 'hasPiAiKey'
+          : 'hasAnthropicKey'
         const hasKey = d[hasKeyField]
         const masked = d[fieldKey] as string | null
         if (hasKey && masked) setSavedMasked(masked)
@@ -344,7 +348,7 @@ function ModelSelector({
         <div className="relative flex-1">
           <select
             value={value}
-            onChange={(e) => void handleChange(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => void handleChange(e.target.value)}
             className="w-full appearance-none pl-3 pr-8 py-2 rounded-lg bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm focus:outline-none focus:border-indigo-500 transition-colors cursor-pointer"
           >
             {models.map((m) => (
@@ -495,7 +499,7 @@ function CodexCliStatusBox() {
   )
 }
 
-function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai'; onChange: (v: 'anthropic' | 'openai') => void }) {
+function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai' | 'pi-ai'; onChange: (v: 'anthropic' | 'openai' | 'pi-ai') => void }) {
   return (
     <div className="flex items-center gap-1 p-1 rounded-xl bg-zinc-800 border border-zinc-700 mb-5">
       <button
@@ -518,23 +522,133 @@ function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai'; on
       >
         OpenAI (GPT)
       </button>
+      <button
+        onClick={() => onChange('pi-ai')}
+        className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          value === 'pi-ai'
+            ? 'bg-zinc-700 text-white shadow-sm'
+            : 'text-zinc-400 hover:text-zinc-200'
+        }`}
+      >
+        pi-ai (Multi-model)
+      </button>
     </div>
   )
 }
 
 function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
-  const [provider, setProvider] = useState<'anthropic' | 'openai' | null>(null)
+  const [provider, setProvider] = useState<'anthropic' | 'openai' | 'pi-ai' | null>(null)
+  const [piAiPreset, setPiAiPreset] = useState('')
+  const [piAiProvider, setPiAiProvider] = useState('openai')
+  const [piAiModel, setPiAiModel] = useState('gpt-4o-mini')
+  const [piAiBaseUrl, setPiAiBaseUrl] = useState('')
+  const [piAiHeaders, setPiAiHeaders] = useState('')
+  const [piAiCompat, setPiAiCompat] = useState('')
+  const [piAiSaved, setPiAiSaved] = useState(false)
+  const [piAiTesting, setPiAiTesting] = useState(false)
+  const [piAiTestStatus, setPiAiTestStatus] = useState<'idle' | 'ok' | 'fail'>('idle')
+  const [piAiTestError, setPiAiTestError] = useState('')
+
+  async function testPiAiConfig() {
+    if (piAiTesting) return
+    setPiAiTesting(true)
+    setPiAiTestStatus('idle')
+    setPiAiTestError('')
+    try {
+      const res = await fetch('/api/settings/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'pi-ai',
+          message: 'ping',
+          ...(piAiProvider.trim() ? { piAiProvider } : {}),
+          ...(piAiModel.trim() ? { piAiModel } : {}),
+          ...(piAiBaseUrl.trim() ? { piAiBaseUrl } : {}),
+          ...(piAiHeaders.trim() ? { piAiHeaders } : {}),
+          ...(piAiCompat.trim() ? { piAiCompat } : {}),
+        }),
+      })
+
+      const data = await res.json().catch(() => ({})) as { working?: boolean; error?: string }
+      const errMsg = data.error ?? 'pi-ai ping failed'
+
+      if (!res.ok) {
+        setPiAiTestStatus('fail')
+        setPiAiTestError(errMsg)
+        onToast({ type: 'error', message: errMsg })
+        return
+      }
+
+      if (data.working) {
+        setPiAiTestStatus('ok')
+        onToast({ type: 'success', message: 'pi-ai config is working (ping)' })
+      } else {
+        setPiAiTestStatus('fail')
+        setPiAiTestError(errMsg)
+        onToast({ type: 'error', message: errMsg })
+      }
+    } catch (err) {
+      console.error('pi-ai ping test failed:', err)
+      const msg = err instanceof Error ? err.message : 'pi-ai ping failed'
+      setPiAiTestStatus('fail')
+      setPiAiTestError(msg)
+      onToast({ type: 'error', message: msg })
+    } finally {
+      setPiAiTesting(false)
+    }
+  }
+
+  function applyPiAiPreset(presetId: string) {
+    if (presetId === 'openai-gpt4o-mini') {
+      setPiAiProvider('openai')
+      setPiAiModel('gpt-4o-mini')
+      setPiAiBaseUrl('')
+      setPiAiHeaders('')
+      setPiAiCompat('')
+      return
+    }
+    if (presetId === 'openrouter-gpt4o-mini') {
+      setPiAiProvider('openrouter')
+      setPiAiModel('openai/gpt-4o-mini')
+      setPiAiBaseUrl('')
+      setPiAiHeaders('{"HTTP-Referer":"http://localhost:3000","X-Title":"Siftly"}')
+      setPiAiCompat('')
+      return
+    }
+    if (presetId === 'groq-llama-31-70b') {
+      setPiAiProvider('groq')
+      setPiAiModel('llama-3.1-70b-versatile')
+      setPiAiBaseUrl('')
+      setPiAiHeaders('')
+      setPiAiCompat('')
+      return
+    }
+    if (presetId === 'ollama-local') {
+      setPiAiProvider('openai')
+      setPiAiModel('llama3.1')
+      setPiAiBaseUrl('http://localhost:11434/v1')
+      setPiAiHeaders('')
+      setPiAiCompat('')
+      return
+    }
+  }
 
   useEffect(() => {
     fetch('/api/settings')
       .then((r) => r.json())
-      .then((d: { provider?: string }) => {
-        setProvider(d.provider === 'openai' ? 'openai' : 'anthropic')
+      .then((d: Record<string, unknown>) => {
+        const p = d.provider === 'openai' ? 'openai' : d.provider === 'pi-ai' ? 'pi-ai' : 'anthropic'
+        setProvider(p)
+        if (typeof d.piAiProvider === 'string') setPiAiProvider(d.piAiProvider)
+        if (typeof d.piAiModel === 'string') setPiAiModel(d.piAiModel)
+        if (typeof d.piAiBaseUrl === 'string' && d.piAiBaseUrl) setPiAiBaseUrl(d.piAiBaseUrl)
+        if (typeof d.piAiHeaders === 'string' && d.piAiHeaders) setPiAiHeaders(d.piAiHeaders)
+        if (typeof d.piAiCompat === 'string' && d.piAiCompat) setPiAiCompat(d.piAiCompat)
       })
       .catch(() => setProvider('anthropic'))
   }, [])
 
-  async function handleProviderChange(newProvider: 'anthropic' | 'openai') {
+  async function handleProviderChange(newProvider: 'anthropic' | 'openai' | 'pi-ai') {
     const prev = provider
     setProvider(newProvider)
     try {
@@ -544,7 +658,7 @@ function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
         body: JSON.stringify({ provider: newProvider }),
       })
       if (!res.ok) throw new Error('Failed to save provider')
-      onToast({ type: 'success', message: `Switched to ${newProvider === 'openai' ? 'OpenAI' : 'Anthropic'}` })
+      onToast({ type: 'success', message: `Switched to ${newProvider === 'openai' ? 'OpenAI' : newProvider === 'pi-ai' ? 'pi-ai' : 'Anthropic'}` })
     } catch {
       setProvider(prev) // revert on failure
       onToast({ type: 'error', message: 'Failed to save provider preference' })
@@ -598,7 +712,7 @@ function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
             </div>
           </div>
         </>
-      ) : (
+      ) : provider === 'openai' ? (
         <>
           <CodexCliStatusBox />
           <div className="space-y-5">
@@ -619,6 +733,159 @@ function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
                 onToast={onToast}
               />
               <p className="text-xs text-zinc-500 mt-1.5">Applies to all AI operations — API key <strong className="text-zinc-400 font-medium">and Codex CLI</strong></p>
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="space-y-5">
+            <div>
+              <ApiKeyField
+                label="pi-ai API Key"
+                placeholder="sk-..."
+                fieldKey="piAiApiKey"
+                hint="Used for all AI operations when provider is pi-ai."
+                docHref="https://github.com/badlogic/pi-mono/tree/main/packages/ai"
+                onToast={onToast}
+                testProvider="pi-ai"
+              />
+
+              <div className="mt-4">
+                <p className="text-sm font-medium text-zinc-300 mb-2">Preset</p>
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <select
+                    value={piAiPreset}
+                    onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+                      const presetId = e.target.value
+                      setPiAiPreset(presetId)
+                      if (presetId) applyPiAiPreset(presetId)
+                    }}
+                    className="w-full appearance-none pl-3 pr-8 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm focus:outline-none focus:border-indigo-500 transition-colors cursor-pointer"
+                  >
+                    <option value="">Custom</option>
+                    <option value="openai-gpt4o-mini">OpenAI — gpt-4o-mini</option>
+                    <option value="openrouter-gpt4o-mini">OpenRouter — openai/gpt-4o-mini</option>
+                    <option value="groq-llama-31-70b">Groq — llama-3.1-70b-versatile</option>
+                    <option value="ollama-local">Ollama (local) — llama3.1 @ http://localhost:11434/v1</option>
+                  </select>
+                  <button
+                    onClick={() => {
+                      if (!piAiPreset) return
+                      applyPiAiPreset(piAiPreset)
+                      onToast({ type: 'success', message: 'Preset applied' })
+                    }}
+                    disabled={!piAiPreset}
+                    className="px-5 py-2.5 rounded-xl bg-zinc-800 hover:bg-zinc-750 disabled:opacity-50 disabled:cursor-not-allowed text-zinc-200 text-sm font-medium transition-colors shrink-0"
+                  >
+                    Apply
+                  </button>
+                </div>
+                <p className="text-xs text-zinc-600 mt-1.5">Presets fill the fields below. You can edit anything after applying.</p>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-4">
+                <div>
+                  <p className="text-sm font-medium text-zinc-300 mb-2">Provider ID</p>
+                  <input
+                    value={piAiProvider}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPiAiProvider(e.target.value)}
+                    placeholder="openai | anthropic | google | groq | openrouter | ..."
+                    className="w-full px-3.5 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-100 placeholder:text-zinc-500 text-sm focus:outline-none focus:border-indigo-500 transition-all duration-200"
+                  />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-zinc-300 mb-2">Model ID</p>
+                  <input
+                    value={piAiModel}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setPiAiModel(e.target.value)}
+                    placeholder="gpt-4o-mini"
+                    className="w-full px-3.5 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-100 placeholder:text-zinc-500 text-sm focus:outline-none focus:border-indigo-500 transition-all duration-200"
+                  />
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <p className="text-sm font-medium text-zinc-300 mb-2">Base URL (optional)</p>
+                <input
+                  value={piAiBaseUrl}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setPiAiBaseUrl(e.target.value)}
+                  placeholder="http://localhost:11434/v1"
+                  className="w-full px-3.5 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-100 placeholder:text-zinc-500 text-sm focus:outline-none focus:border-indigo-500 transition-all duration-200"
+                />
+                <p className="text-xs text-zinc-600 mt-1.5">Set this for any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, LiteLLM, etc.).</p>
+              </div>
+
+              <div className="mt-4">
+                <p className="text-sm font-medium text-zinc-300 mb-2">Headers JSON (optional)</p>
+                <textarea
+                  value={piAiHeaders}
+                  onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setPiAiHeaders(e.target.value)}
+                  placeholder='{"Authorization":"Bearer ..."}'
+                  rows={3}
+                  className="w-full px-3.5 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-100 placeholder:text-zinc-500 text-sm focus:outline-none focus:border-indigo-500 transition-all duration-200 font-mono"
+                />
+              </div>
+
+              <div className="mt-4">
+                <p className="text-sm font-medium text-zinc-300 mb-2">Compat JSON (optional)</p>
+                <textarea
+                  value={piAiCompat}
+                  onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setPiAiCompat(e.target.value)}
+                  placeholder='{"supportsDeveloperRole":false}'
+                  rows={3}
+                  className="w-full px-3.5 py-2.5 rounded-xl bg-zinc-800 border border-zinc-700 text-zinc-100 placeholder:text-zinc-500 text-sm focus:outline-none focus:border-indigo-500 transition-all duration-200 font-mono"
+                />
+              </div>
+
+              <div className="flex items-center gap-2 mt-4">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPiAiSaved(false)
+                    void fetch('/api/settings', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({
+                        piAiProvider,
+                        piAiModel,
+                        piAiBaseUrl,
+                        piAiHeaders,
+                        piAiCompat,
+                      }),
+                    }).then((r) => {
+                      if (!r.ok) throw new Error('Failed')
+                      setPiAiSaved(true)
+                      setTimeout(() => setPiAiSaved(false), 2000)
+                    }).catch(() => onToast({ type: 'error', message: 'Failed to save pi-ai settings' }))
+                  }}
+                  className="px-5 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition-colors"
+                >
+                  Save pi-ai config
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void testPiAiConfig()}
+                  disabled={piAiTesting}
+                  className="px-5 py-2.5 rounded-xl bg-zinc-800 hover:bg-zinc-750 disabled:opacity-50 disabled:cursor-not-allowed text-zinc-200 text-sm font-medium transition-colors"
+                >
+                  {piAiTesting ? 'Testing…' : 'Test config (ping)'}
+                </button>
+                {piAiTestStatus === 'ok' && (
+                  <span className="flex items-center gap-1 text-xs text-emerald-400">
+                    <Check size={12} /> Working
+                  </span>
+                )}
+                {piAiTestStatus === 'fail' && (
+                  <span className="flex items-center gap-1 text-xs text-red-400" title={piAiTestError}>
+                    <X size={12} /> Failed
+                  </span>
+                )}
+                {piAiSaved && (
+                  <span className="flex items-center gap-1 text-xs text-emerald-400">
+                    <Check size={12} /> Saved
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </>
@@ -756,7 +1023,7 @@ function DangerZoneSection({ onToast }: { onToast: (t: Toast) => void }) {
 const TECH_STACK = [
   { label: 'Next.js 15', color: 'bg-zinc-800 text-zinc-300 border-zinc-700' },
   { label: 'Prisma + SQLite', color: 'bg-zinc-800 text-zinc-300 border-zinc-700' },
-  { label: 'Anthropic / OpenAI', color: 'bg-blue-500/10 text-blue-300 border-blue-500/20' },
+  { label: 'Anthropic / OpenAI / pi-ai', color: 'bg-blue-500/10 text-blue-300 border-blue-500/20' },
   { label: 'React Flow', color: 'bg-zinc-800 text-zinc-300 border-zinc-700' },
   { label: 'Tailwind CSS', color: 'bg-cyan-500/10 text-cyan-300 border-cyan-500/20' },
 ]
@@ -834,9 +1101,13 @@ function XOAuthSection({ onToast }: { onToast: (t: Toast) => void }) {
   const [clientSecret, setClientSecret] = useState('')
   const [savedId, setSavedId] = useState<string | null>(null)
   const [savedSecret, setSavedSecret] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
 
+  const [callbackUrl, setCallbackUrl] = useState('/api/import/x-oauth/callback')
+
   useEffect(() => {
+    setLoading(true)
     fetch('/api/settings')
       .then((r) => r.json())
       .then((d: Record<string, unknown>) => {
@@ -896,9 +1167,9 @@ function XOAuthSection({ onToast }: { onToast: (t: Toast) => void }) {
     }
   }
 
-  const callbackUrl = typeof window !== 'undefined'
-    ? `${window.location.origin}/api/import/x-oauth/callback`
-    : '/api/import/x-oauth/callback'
+  useEffect(() => {
+    setCallbackUrl(`${window.location.origin}/api/import/x-oauth/callback`)
+  }, [])
 
   return (
     <Section

--- a/lib/ai-client.ts
+++ b/lib/ai-client.ts
@@ -1,13 +1,168 @@
 import Anthropic from '@anthropic-ai/sdk'
 import OpenAI from 'openai'
+import { complete, getModel, type Model } from '@mariozechner/pi-ai'
+import prisma from '@/lib/db'
 import { resolveAnthropicClient } from './claude-cli-auth'
 import { resolveOpenAIClient } from './openai-auth'
-import { getProvider } from './settings'
+import { getPiAiModel, getPiAiProviderId, getProvider } from './settings'
 
 export interface AIContentBlock {
   type: 'text' | 'image'
   text?: string
   source?: { type: 'base64'; media_type: string; data: string }
+}
+
+type PiAiCompat = Record<string, unknown>
+
+function safeJsonParseObject(raw: string | undefined | null): Record<string, unknown> | null {
+  if (!raw?.trim()) return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+    return null
+  } catch {
+    return null
+  }
+}
+
+function resolvePiAiModelFromConfig(options: {
+  providerId: string | null
+  modelId: string | null
+  baseUrl: string | null
+  headersJson: string | null
+  compatJson: string | null
+}): Model<any> {
+  const providerId = (options.providerId ?? 'openai').trim() || 'openai'
+  const modelId = (options.modelId ?? 'gpt-4o-mini').trim() || 'gpt-4o-mini'
+
+  const baseUrl = options.baseUrl?.trim()
+
+  // If no custom baseUrl/headers/compat are set, prefer pi-ai's built-in registry.
+  if (!baseUrl && !options.headersJson && !options.compatJson) {
+    const model = getModel(providerId as any, modelId as any) as any
+    if (!model) {
+      throw new Error(
+        `pi-ai model not found for provider="${providerId}" model="${modelId}". Update Settings → AI Provider → pi-ai (Provider ID / Model ID), or use a Base URL for an OpenAI-compatible endpoint.`
+      )
+    }
+    return model
+  }
+
+  const headers = safeJsonParseObject(options.headersJson) ?? undefined
+  const compat = safeJsonParseObject(options.compatJson) as PiAiCompat | null
+
+  // If no custom baseUrl is provided but headers/compat are, start from pi-ai's registry
+  // and overlay the extra fields.
+  if (!baseUrl) {
+    const base = getModel(providerId as any, modelId as any) as any
+    if (!base) {
+      throw new Error(
+        `pi-ai model not found for provider="${providerId}" model="${modelId}". Update Settings → AI Provider → pi-ai (Provider ID / Model ID), or set Base URL if you're using an OpenAI-compatible endpoint.`
+      )
+    }
+    return {
+      ...base,
+      ...(headers ? { headers: headers as Record<string, string> } : {}),
+      ...(compat ? { compat: compat as any } : {}),
+    } as any
+  }
+
+  // Default to OpenAI-compatible API when using a custom baseUrl.
+  // This supports many providers like Ollama/vLLM/LM Studio/LiteLLM.
+  const custom: Model<'openai-completions'> = {
+    id: modelId,
+    name: modelId,
+    api: 'openai-completions',
+    provider: 'openai',
+    baseUrl,
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 8192,
+    ...(headers ? { headers: headers as Record<string, string> } : {}),
+    ...(compat ? { compat: compat as any } : {}),
+  }
+
+  return custom as any
+}
+
+export class PiAiClient implements AIClient {
+  provider = 'pi-ai' as const
+  constructor(
+    private model: Model<any>,
+    private apiKey: string | undefined,
+  ) {}
+
+  private getValidatedModel(): Model<any> {
+    const m = this.model as any
+    if (!m) {
+      throw new Error('pi-ai model is not configured. Go to Settings → AI Provider → pi-ai.')
+    }
+    if (!m.provider) {
+      throw new Error('pi-ai model is invalid (missing provider). Check Settings → AI Provider → pi-ai.')
+    }
+    return this.model
+  }
+
+  async createMessage(params: { model: string; max_tokens: number; messages: AIMessage[] }): Promise<AIResponse> {
+    const model = this.getValidatedModel()
+    const baseUrl = (model as any).baseUrl as string | undefined
+    const apiKey = this.apiKey || (baseUrl ? 'local' : undefined)
+    const messages = params.messages.map((m) => {
+      const content = typeof m.content === 'string'
+        ? [{ type: 'text' as const, text: m.content }]
+        : m.content.map((b) => {
+            if (b.type === 'image' && b.source) {
+              return { type: 'image' as const, data: b.source.data, mimeType: b.source.media_type }
+            }
+            return { type: 'text' as const, text: b.text ?? '' }
+          })
+
+      return {
+        role: m.role,
+        content,
+      }
+    })
+
+    const response = await complete(
+      model,
+      {
+        messages: messages as any,
+      } as any,
+      {
+        apiKey,
+        maxTokens: params.max_tokens,
+      } as any,
+    )
+
+    if (typeof (response as any) === 'string') {
+      return { text: response as any }
+    }
+
+    const contentBlocks: any[] = Array.isArray((response as any).content) ? (response as any).content : []
+    const text = contentBlocks
+      .map((b: any) => {
+        if (!b) return ''
+        if (typeof b.text === 'string') return b.text
+        if (typeof b.output_text === 'string') return b.output_text
+        if (typeof b.thinking === 'string') return b.thinking
+        if (typeof b.refusal === 'string') return b.refusal
+        if (typeof b.content === 'string') return b.content
+        return ''
+      })
+      .filter((t: string) => t.trim().length > 0)
+      .join('')
+
+    const errorMessage = typeof (response as any).errorMessage === 'string' ? (response as any).errorMessage : ''
+    const topLevelText = typeof (response as any).text === 'string' ? (response as any).text : ''
+    const topLevelOutputText = typeof (response as any).output_text === 'string' ? (response as any).output_text : ''
+    const finalText = text || topLevelText || topLevelOutputText || errorMessage || JSON.stringify(response)
+
+    return {
+      text: finalText,
+    }
+  }
 }
 
 export interface AIMessage {
@@ -20,7 +175,7 @@ export interface AIResponse {
 }
 
 export interface AIClient {
-  provider: 'anthropic' | 'openai'
+  provider: 'anthropic' | 'openai' | 'pi-ai'
   createMessage(params: {
     model: string
     max_tokens: number
@@ -60,7 +215,7 @@ export class AnthropicAIClient implements AIClient {
       messages,
     })
 
-    const textBlock = msg.content.find(b => b.type === 'text')
+    const textBlock = msg.content.find((b: Anthropic.ContentBlock) => b.type === 'text')
     return { text: textBlock && 'text' in textBlock ? textBlock.text : '' }
   }
 }
@@ -108,6 +263,45 @@ export async function resolveAIClient(options: {
   if (provider === 'openai') {
     const client = resolveOpenAIClient(options)
     return new OpenAIAIClient(client)
+  }
+
+  if (provider === 'pi-ai') {
+    const providerId = await getPiAiProviderId()
+    const modelId = await getPiAiModel()
+
+    const [piAiKey, piAiBaseUrl, piAiHeaders, piAiCompat] = await Promise.all([
+      prisma.setting.findUnique({ where: { key: 'piAiApiKey' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiBaseUrl' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiHeaders' } }),
+      prisma.setting.findUnique({ where: { key: 'piAiCompat' } }),
+    ])
+
+    const baseUrl =
+      piAiBaseUrl?.value?.trim() ||
+      process.env.PI_AI_BASE_URL?.trim() ||
+      process.env.PIAI_BASE_URL?.trim() ||
+      null
+
+    const headersJson =
+      piAiHeaders?.value ||
+      process.env.PI_AI_HEADERS?.trim() ||
+      null
+
+    const compatJson =
+      piAiCompat?.value ||
+      process.env.PI_AI_COMPAT?.trim() ||
+      null
+
+    const model = resolvePiAiModelFromConfig({ providerId, modelId, baseUrl, headersJson, compatJson })
+    const apiKey =
+      options.overrideKey?.trim() ||
+      options.dbKey?.trim() ||
+      piAiKey?.value?.trim() ||
+      process.env.PI_AI_API_KEY?.trim() ||
+      process.env.PIAI_API_KEY?.trim() ||
+      undefined
+
+    return new PiAiClient(model, apiKey)
   }
 
   const client = resolveAnthropicClient(options)

--- a/lib/categorizer.ts
+++ b/lib/categorizer.ts
@@ -209,25 +209,45 @@ ${JSON.stringify(tweetData, null, 1)}`
 }
 
 function parseCategorizationResponse(text: string, validSlugs: Set<string>): CategorizationResult[] {
-  const jsonMatch = text.match(/\[[\s\S]*\]/)
-  if (!jsonMatch) throw new Error('No JSON array found in AI response')
+  const stripped = text.replace(/```[a-zA-Z]*\s*/g, '').replace(/```/g, '')
+  const objectArrayCandidates = stripped.match(/\[\s*\{[\s\S]*?\}\s*\]/g) ?? []
+  const anyArrayCandidates = stripped.match(/\[[\s\S]*?\]/g) ?? []
+  const objectCandidates = stripped.match(/\{[\s\S]*?\}/g) ?? []
+  const candidates = objectArrayCandidates.length
+    ? objectArrayCandidates
+    : (anyArrayCandidates.length ? anyArrayCandidates : objectCandidates)
 
-  const parsed: unknown = JSON.parse(jsonMatch[0])
-  if (!Array.isArray(parsed)) throw new Error('Claude response is not an array')
+  for (const raw of candidates) {
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      const asArray: Record<string, unknown>[] = Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>[])
+        : (typeof parsed === 'object' && parsed !== null ? [parsed as Record<string, unknown>] : [])
 
-  return (parsed as Record<string, unknown>[]).map((item): CategorizationResult => {
-    const tweetId = String(item.tweetId ?? '')
-    const rawAssignments = Array.isArray(item.assignments) ? item.assignments : []
+      if (asArray.length === 0) continue
 
-    const assignments: CategoryAssignment[] = (rawAssignments as Record<string, unknown>[])
-      .map((a) => ({
-        category: String(a.category ?? ''),
-        confidence: typeof a.confidence === 'number' ? Math.min(1, Math.max(0.5, a.confidence)) : 0.8,
-      }))
-      .filter((a) => validSlugs.has(a.category))
+      const results = asArray.map((item): CategorizationResult => {
+        const tweetId = String(item.tweetId ?? item.id ?? '')
+        const rawAssignments = Array.isArray(item.assignments) ? item.assignments : []
 
-    return { tweetId, assignments }
-  })
+        const assignments: CategoryAssignment[] = (rawAssignments as Record<string, unknown>[])
+          .map((a) => ({
+            category: String(a.category ?? ''),
+            confidence: typeof a.confidence === 'number' ? Math.min(1, Math.max(0.5, a.confidence)) : 0.8,
+          }))
+          .filter((a) => validSlugs.has(a.category))
+
+        return { tweetId, assignments }
+      }).filter((r) => r.tweetId)
+
+      if (results.length === 0) continue
+      return results
+    } catch {
+      // try next candidate
+    }
+  }
+
+  throw new Error('No JSON object/array found in AI response')
 }
 
 export async function categorizeBatch(
@@ -255,7 +275,7 @@ export async function categorizeBatch(
         console.warn('[categorize] Codex CLI failed, falling back to SDK:', result.error)
       }
     }
-  } else {
+  } else if (provider === 'anthropic') {
     if (await getCliAvailability()) {
       const model = await getActiveModel()
       const cliModel = modelNameToCliAlias(model)
@@ -275,7 +295,11 @@ export async function categorizeBatch(
 
   // Fallback to SDK (requires API key)
   if (!client) {
-    throw new Error('No CLI available and no API key configured.')
+    if (provider === 'pi-ai') {
+      client = await resolveAIClient()
+    } else {
+      throw new Error('No CLI available and no API key configured.')
+    }
   }
 
   const model = await getActiveModel()
@@ -285,9 +309,20 @@ export async function categorizeBatch(
     messages: [{ role: 'user', content: prompt }],
   })
 
-  if (!response.text) throw new Error('No text content in AI response')
+  if (!response.text) {
+    throw new Error(`No text content in AI response (provider=${provider} model=${model})`)
+  }
 
-  return parseCategorizationResponse(response.text, new Set(allSlugs))
+  try {
+    return parseCategorizationResponse(response.text, new Set(allSlugs))
+  } catch (err) {
+    const preview = response.text.replace(/\s+/g, ' ').slice(0, 700)
+    console.warn(
+      `[categorize] response parse failed provider=${provider} model=${model} len=${response.text.length} ` +
+        `preview=${JSON.stringify(preview)}`,
+    )
+    throw err
+  }
 }
 
 export async function writeCategoryResults(results: CategorizationResult[]): Promise<void> {
@@ -399,7 +434,7 @@ export async function categorizeAll(
 
   // Resolve auth once — avoids re-resolving inside every batch call
   const provider = await getProvider()
-  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const keyName = provider === 'openai' ? 'openaiApiKey' : provider === 'pi-ai' ? 'piAiApiKey' : 'anthropicApiKey'
   const apiKeySetting = await prisma.setting.findUnique({ where: { key: keyName } })
   let client: AIClient | null = null
   try {

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -4,11 +4,17 @@ import prisma from '@/lib/db'
 let _cachedModel: string | null = null
 let _modelCacheExpiry = 0
 
-let _cachedProvider: 'anthropic' | 'openai' | null = null
+let _cachedProvider: 'anthropic' | 'openai' | 'pi-ai' | null = null
 let _providerCacheExpiry = 0
 
 let _cachedOpenAIModel: string | null = null
 let _openAIModelCacheExpiry = 0
+
+let _cachedPiAiModel: string | null = null
+let _piAiModelCacheExpiry = 0
+
+let _cachedPiAiProviderId: string | null = null
+let _piAiProviderIdCacheExpiry = 0
 
 const CACHE_TTL = 5 * 60 * 1000
 
@@ -16,20 +22,21 @@ const CACHE_TTL = 5 * 60 * 1000
  * Get the configured Anthropic model from settings (cached for 5 minutes).
  */
 export async function getAnthropicModel(): Promise<string> {
-  if (_cachedModel && Date.now() < _modelCacheExpiry) return _cachedModel
+  if (_cachedModel !== null && Date.now() < _modelCacheExpiry) return _cachedModel
   const setting = await prisma.setting.findUnique({ where: { key: 'anthropicModel' } })
-  _cachedModel = setting?.value ?? 'claude-haiku-4-5-20251001'
+  const value = setting?.value ?? 'claude-haiku-4-5-20251001'
+  _cachedModel = value
   _modelCacheExpiry = Date.now() + CACHE_TTL
-  return _cachedModel
+  return value
 }
 
 /**
  * Get the active AI provider (cached for 5 minutes).
  */
-export async function getProvider(): Promise<'anthropic' | 'openai'> {
-  if (_cachedProvider && Date.now() < _providerCacheExpiry) return _cachedProvider
+export async function getProvider(): Promise<'anthropic' | 'openai' | 'pi-ai'> {
+  if (_cachedProvider !== null && Date.now() < _providerCacheExpiry) return _cachedProvider
   const setting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
-  _cachedProvider = setting?.value === 'openai' ? 'openai' : 'anthropic'
+  _cachedProvider = setting?.value === 'openai' ? 'openai' : setting?.value === 'pi-ai' ? 'pi-ai' : 'anthropic'
   _providerCacheExpiry = Date.now() + CACHE_TTL
   return _cachedProvider
 }
@@ -38,11 +45,30 @@ export async function getProvider(): Promise<'anthropic' | 'openai'> {
  * Get the configured OpenAI model from settings (cached for 5 minutes).
  */
 export async function getOpenAIModel(): Promise<string> {
-  if (_cachedOpenAIModel && Date.now() < _openAIModelCacheExpiry) return _cachedOpenAIModel
+  if (_cachedOpenAIModel !== null && Date.now() < _openAIModelCacheExpiry) return _cachedOpenAIModel
   const setting = await prisma.setting.findUnique({ where: { key: 'openaiModel' } })
-  _cachedOpenAIModel = setting?.value ?? 'gpt-4.1-mini'
+  const value = setting?.value ?? 'gpt-4.1-mini'
+  _cachedOpenAIModel = value
   _openAIModelCacheExpiry = Date.now() + CACHE_TTL
-  return _cachedOpenAIModel
+  return value
+}
+
+export async function getPiAiProviderId(): Promise<string> {
+  if (_cachedPiAiProviderId !== null && Date.now() < _piAiProviderIdCacheExpiry) return _cachedPiAiProviderId
+  const setting = await prisma.setting.findUnique({ where: { key: 'piAiProvider' } })
+  const value = setting?.value ?? 'openai'
+  _cachedPiAiProviderId = value
+  _piAiProviderIdCacheExpiry = Date.now() + CACHE_TTL
+  return value
+}
+
+export async function getPiAiModel(): Promise<string> {
+  if (_cachedPiAiModel !== null && Date.now() < _piAiModelCacheExpiry) return _cachedPiAiModel
+  const setting = await prisma.setting.findUnique({ where: { key: 'piAiModel' } })
+  const value = setting?.value ?? 'gpt-4o-mini'
+  _cachedPiAiModel = value
+  _piAiModelCacheExpiry = Date.now() + CACHE_TTL
+  return value
 }
 
 /**
@@ -50,7 +76,9 @@ export async function getOpenAIModel(): Promise<string> {
  */
 export async function getActiveModel(): Promise<string> {
   const provider = await getProvider()
-  return provider === 'openai' ? getOpenAIModel() : getAnthropicModel()
+  if (provider === 'openai') return getOpenAIModel()
+  if (provider === 'pi-ai') return getPiAiModel()
+  return getAnthropicModel()
 }
 
 /**
@@ -63,4 +91,8 @@ export function invalidateSettingsCache(): void {
   _providerCacheExpiry = 0
   _cachedOpenAIModel = null
   _openAIModelCacheExpiry = 0
+  _cachedPiAiModel = null
+  _piAiModelCacheExpiry = 0
+  _cachedPiAiProviderId = null
+  _piAiProviderIdCacheExpiry = 0
 }

--- a/lib/vision-analyzer.ts
+++ b/lib/vision-analyzer.ts
@@ -88,7 +88,9 @@ async function analyzeImageViaCli(imageUrl: string): Promise<string> {
     const jsonMatch = result.data.match(/\{[\s\S]*\}/)
     if (!jsonMatch) return ''
     try { JSON.parse(jsonMatch[0]); return jsonMatch[0] } catch { return '' }
-  } else {
+  }
+
+  if (provider === 'anthropic') {
     if (!(await getCliAvailability())) return ''
     const model = await getActiveModel()
     const cliModel = modelNameToCliAlias(model)
@@ -98,6 +100,8 @@ async function analyzeImageViaCli(imageUrl: string): Promise<string> {
     if (!jsonMatch) return ''
     try { JSON.parse(jsonMatch[0]); return jsonMatch[0] } catch { return '' }
   }
+
+  return ''
 }
 
 async function analyzeImageWithRetry(
@@ -381,18 +385,33 @@ export async function enrichBatchSemanticTags(
   const provider = await getProvider()
 
   // Helper to parse enrichment response
-  const parseResponse = (text: string): EnrichmentResult[] => {
-    const match = text.match(/\[[\s\S]*\]/)
-    if (!match) return []
-    const parsed: unknown = JSON.parse(match[0])
-    if (!Array.isArray(parsed)) return []
-    return (parsed as Record<string, unknown>[]).map((item): EnrichmentResult => ({
-      id: String(item.id ?? ''),
-      tags: Array.isArray(item.tags) ? (item.tags as unknown[]).map(String).filter(Boolean) : [],
-      sentiment: String(item.sentiment ?? 'neutral'),
-      people: Array.isArray(item.people) ? (item.people as unknown[]).map(String).filter(Boolean) : [],
-      companies: Array.isArray(item.companies) ? (item.companies as unknown[]).map(String).filter(Boolean) : [],
-    })).filter((r) => r.id)
+  const parseResponse = (text: string): { results: EnrichmentResult[]; candidates: string[] } => {
+    const stripped = text.replace(/```[a-zA-Z]*\s*/g, '').replace(/```/g, '')
+    const objectArrayCandidates = stripped.match(/\[\s*\{[\s\S]*?\}\s*\]/g) ?? []
+    const anyArrayCandidates = stripped.match(/\[[\s\S]*?\]/g) ?? []
+    const candidates = objectArrayCandidates.length ? objectArrayCandidates : anyArrayCandidates
+
+    for (const raw of candidates) {
+      try {
+        const parsed: unknown = JSON.parse(raw)
+        if (!Array.isArray(parsed)) continue
+        const results = (parsed as Record<string, unknown>[])
+          .map((item): EnrichmentResult => ({
+            id: String(item.id ?? ''),
+            tags: Array.isArray(item.tags) ? (item.tags as unknown[]).map(String).filter(Boolean) : [],
+            sentiment: String(item.sentiment ?? 'neutral'),
+            people: Array.isArray(item.people) ? (item.people as unknown[]).map(String).filter(Boolean) : [],
+            companies: Array.isArray(item.companies) ? (item.companies as unknown[]).map(String).filter(Boolean) : [],
+          }))
+          .filter((r) => r.id)
+
+        if (results.length === 0) continue
+        return { results, candidates }
+      } catch {
+        // try next candidate
+      }
+    }
+    return { results: [], candidates }
   }
 
   // Prefer CLI over SDK
@@ -400,18 +419,18 @@ export async function enrichBatchSemanticTags(
     if (await getCodexCliAvailability()) {
       const result = await codexPrompt(prompt, { timeoutMs: 90_000 })
       if (result.success && result.data) {
-        try { return parseResponse(result.data) }
+        try { return parseResponse(result.data).results }
         catch { console.warn('[enrich] Codex CLI response parse failed, falling back to SDK') }
       }
     }
-  } else {
+  } else if (provider === 'anthropic') {
     if (await getCliAvailability()) {
       const model = await getActiveModel()
       const cliModel = modelNameToCliAlias(model)
 
       const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 90_000 })
       if (result.success && result.data) {
-        try { return parseResponse(result.data) }
+        try { return parseResponse(result.data).results }
         catch { console.warn('[enrich] CLI response parse failed, falling back to SDK') }
       }
     }
@@ -433,9 +452,17 @@ export async function enrichBatchSemanticTags(
         max_tokens: 4096,
         messages: [{ role: 'user', content: prompt }],
       })
-      const results = parseResponse(response.text)
+      const parsed = parseResponse(response.text)
+      const results = parsed.results
       if (results.length > 0) return results
-      console.warn(`[enrich] no JSON array in response (attempt ${attempt + 1})`)
+      const preview = response.text
+        .replace(/\s+/g, ' ')
+        .slice(0, 700)
+
+      console.warn(
+        `[enrich] no JSON array in response (attempt ${attempt + 1}) provider=${provider} model=${model} ` +
+          `len=${response.text.length} candidates=${parsed.candidates.length} preview=${JSON.stringify(preview)}`,
+      )
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err)
       console.warn(`[enrich] batch failed (attempt ${attempt + 1}): ${errMsg.slice(0, 120)}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "@mariozechner/pi-ai": "^0.5.0",
         "@prisma/adapter-better-sqlite3": "^7.4.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.8",
@@ -1048,6 +1049,29 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@google/genai": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.46.0.tgz",
+      "integrity": "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -1629,6 +1653,90 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mariozechner/pi-ai": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.5.48.tgz",
+      "integrity": "sha512-EbasC5UKLYD9S9jyurU0mWLIxt5crQJ6Gt73mdV1jB5pCpLre9ixSwTMraBhQYRm3oN0gHGuGf+lWxgKA1QQtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.61.0",
+        "@google/genai": "^1.17.0",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "5.21.0",
+        "partial-json": "^0.1.7",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.61.0.tgz",
+      "integrity": "sha512-GnlOXrPxow0uoaVB3DGNh9EJBU1MyagCBCLpU+bwDVlj/oOPYIwoiasMWlykkfYcQOrDP2x/zHnRD0xN7PeZPw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/openai": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.21.0.tgz",
+      "integrity": "sha512-E9LuV51vgvwbahPJaZu2x4V6SWMq9g3X6Bj2/wnFiNfV7lmAxYVxPxcQNZqCWbAVMaEoers9HzIxpOp6Vvgn8w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mrleebo/prisma-ast": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
@@ -2032,6 +2140,70 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -2843,6 +3015,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3225,7 +3403,6 @@
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
       "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3250,6 +3427,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -3870,6 +4053,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3886,6 +4078,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -4208,6 +4439,15 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -4323,6 +4563,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/c12": {
       "version": "3.1.0",
@@ -4721,6 +4967,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4779,7 +5034,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4948,6 +5202,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/effect": {
@@ -5696,6 +5959,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
@@ -5723,7 +5992,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5770,6 +6038,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5778,6 +6062,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5883,6 +6190,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5943,6 +6262,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generate-function": {
@@ -6128,6 +6475,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6289,6 +6662,19 @@
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -6894,6 +7280,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6967,6 +7362,27 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7327,7 +7743,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -7466,7 +7881,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mysql2": {
@@ -7655,6 +8069,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -7672,6 +8106,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-fetch-native": {
@@ -7941,6 +8393,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7959,6 +8433,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -8192,6 +8672,30 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -8477,6 +8981,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -9545,7 +10058,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -9697,6 +10209,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9818,6 +10339,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9850,13 +10392,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "devOptional": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@mariozechner/pi-ai": "^0.5.0",
     "@prisma/adapter-better-sqlite3": "^7.4.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",


### PR DESCRIPTION
## Summary
- Adds `pi-ai` multi-provider support, including UI + persisted settings (provider/model/baseUrl/headers/compat).
- Adds Settings test button (ping) and improves `/api/settings/test` behavior and UX feedback.
- Enables LM Studio / OpenAI-compatible baseUrl usage without a real API key (injects dummy key for pi-ai/OpenAI SDK requirement).
- Fixes Settings hydration mismatch (X OAuth callback URL).
- Hardens enrich + categorize JSON extraction for fenced JSON/nested arrays and adds detailed logs.

## Testing
- Settings → pi-ai → Test config (ping)
- Bookmark import pipeline: enrich + categorize stages with LM Studio baseUrl.