### PR TITLE
fix: install prisma in runner stage to fix `prisma generate`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,10 +22,12 @@ WORKDIR /app
 RUN apk add --no-cache python3 make g++
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-# Install production deps (includes prisma + better-sqlite3, rebuilt for this image)
+# Install production deps (includes better-sqlite3, rebuilt for this image)
+# prisma and @prisma/client are devDependencies but are required at runtime
+# for the runner stage to generate the Prisma client.
 COPY package*.json ./
 COPY prisma ./prisma
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && npm install --no-save prisma @prisma/client
 
 # Re-generate Prisma client in runner stage
 RUN node_modules/.bin/prisma generate


### PR DESCRIPTION
## Problem

`prisma` and `@prisma/client` are listed as `devDependencies` in `package.json`. The runner stage of the Dockerfile uses `npm ci --omit=dev`, which correctly skips dev dependencies — but then immediately tries to run:

```dockerfile
RUN node_modules/.bin/prisma generate
```

This fails with:
```
/bin/sh: node_modules/.bin/prisma: not found
```

Anyone building the Docker image from source hits this error.

## Fix

Append `&& npm install --no-save prisma @prisma/client` to the production install step so the Prisma CLI and client are available in the runner stage without being added to permanent production dependencies.

```dockerfile
RUN npm ci --omit=dev && npm install --no-save prisma @prisma/client
```

## Testing

Built and ran the container locally — `prisma generate` completes successfully and the app starts.