### PR TITLE
fix: persist SQLite database to mounted volume in Docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - "3000:3000"
     env_file:
       - .env
+    environment:
+      # Override DATABASE_URL from .env to point at the persistent volume mount.
+      # Without this, SQLite is written inside the image at /app/prisma/dev.db
+      # and all data is lost whenever the container is rebuilt or replaced.
+      - DATABASE_URL=file:/data/siftly.db
     volumes:
       - siftly_data:/data
     restart: unless-stopped


### PR DESCRIPTION
## Problem

The `docker-compose.yml` declares a `siftly_data` volume mounted at `/data`, but the `DATABASE_URL` from `.env` resolves to `/app/prisma/dev.db` — **inside the image layer, not the volume**.

Every time the container is rebuilt or replaced, all persisted data (API keys, X OAuth tokens, categorization settings, sync config) is silently lost.

## Root cause

```yaml
# docker/docker-compose.yml
volumes:
  - siftly_data:/data    # ← volume is here
```

```env
# .env
DATABASE_URL="file:./prisma/dev.db"  # ← resolves to /app/prisma/dev.db, NOT /data
```

## Fix

Add an `environment` override in `docker-compose.yml` to redirect the database to the persistent volume:

```yaml
environment:
  - DATABASE_URL=file:/data/siftly.db
```

The default in `.env` is left unchanged — local (non-Docker) development is unaffected.

## Testing

Rebuilt and restarted the container; settings saved before the rebuild were still present after.