### PR TITLE
fix(x-oauth): resolve user ID before /users/{id}/bookmarks call

### DIFF
--- a/app/api/import/x-oauth/fetch/route.ts
+++ b/app/api/import/x-oauth/fetch/route.ts
@@ -92,6 +92,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated with X. Please connect your account first.' }, { status: 401 })
   }
 
+  // Resolve authenticated user ID — X API rejects /users/me/bookmarks, requires the numeric ID.
+  let userId: string
+  {
+    const meRes = await fetch('https://api.x.com/2/users/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!meRes.ok) {
+      const errText = await meRes.text()
+      console.error('X API users/me error:', meRes.status, errText)
+      return NextResponse.json({ error: `X API users/me error: ${meRes.status}` }, { status: 502 })
+    }
+    const meJson = await meRes.json() as { data?: { id: string } }
+    if (!meJson.data?.id) {
+      return NextResponse.json({ error: 'Failed to resolve authenticated user id' }, { status: 502 })
+    }
+    userId = meJson.data.id
+  }
+
   let imported = 0
   let skipped = 0
   let total = 0
@@ -107,7 +125,7 @@ export async function POST(req: NextRequest) {
     })
     if (nextToken) params.set('pagination_token', nextToken)
 
-    const res = await fetch(`https://api.x.com/2/users/me/bookmarks?${params}`, {
+    const res = await fetch(`https://api.x.com/2/users/${userId}/bookmarks?${params}`, {
       headers: { Authorization: `Bearer ${token}` },
     })
 


### PR DESCRIPTION
## Summary
- Resolves authenticated user ID via `/2/users/me` before calling `/2/users/{id}/bookmarks`
- Fixes hard 400 from X API v2 on every X OAuth bookmark import

## The bug
`app/api/import/x-oauth/fetch/route.ts` calls `https://api.x.com/2/users/me/bookmarks?...`. The X API v2 rejects this:

```json
{
  "errors": [{
    "parameters": {"id": ["me"]},
    "message": "The `id` query parameter value [me] is not valid"
  }],
  "title": "Invalid Request",
  "type": "https://api.twitter.com/2/problems/invalid-request"
}
```

The `/users/{id}/bookmarks` endpoint requires the numeric user ID — unlike many `/2/tweets/*` endpoints, it does not accept `me` as an alias.

Result: every X OAuth import fails with `"X API error: 400"` before any bookmarks are fetched. Reproduced on a brand-new OAuth 2.0 connection on the new pay-per-use developer console (`console.x.com`) as of April 2026.

## The fix
Call `/2/users/me` once at the start of `POST /api/import/x-oauth/fetch` to resolve the numeric ID, then use it for all `/users/{id}/bookmarks` pagination requests. One extra request per import — negligible against the bookmark pagination loop, and `/users/me` doesn't consume bookmark-list rate limits.

## Test plan
- [x] Tested locally against my own X account on a fresh OAuth 2.0 connection
- [x] 98 bookmarks imported successfully (was failing with 400 before)
- [x] Pagination still works (verified with `maxPages: 20`)
- [x] No new TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)