### PR TITLE
feat: add OpenAI-compatible provider for local LLMs and custom APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,23 @@ DATABASE_URL="file:./prisma/dev.db"
 # ── Import options ──────────────────────────────────────────────────
 # Automatically trigger AI categorization after a successful import.
 # AUTO_CATEGORIZE_AFTER_IMPORT=true
+
+# ── OpenAI-compatible provider ──────────────────────────────────────
+# Use ANY provider with an OpenAI-compatible chat completions API.
+# Works with: Ollama, llama.cpp, vLLM, LM Studio, Together AI, Groq,
+#             Fireworks, Deepseek, Mistral, LocalAI, text-generation-webui, etc.
+#
+# Base URL (required) — the /v1 endpoint of your provider:
+#   Ollama:       http://localhost:11434/v1
+#   LM Studio:    http://localhost:1234/v1
+#   llama.cpp:    http://localhost:8080/v1
+#   vLLM:         http://localhost:8000/v1
+#   Together AI:  https://api.together.xyz/v1
+#   Groq:         https://api.groq.com/openai/v1
+# OPENAI_COMPATIBLE_BASE_URL=http://localhost:11434/v1
+
+# API key (optional — most local servers don't need one)
+# OPENAI_COMPATIBLE_API_KEY=
+
+# Model name is configured in the Settings UI (not here) since it
+# depends on what's available at your endpoint.

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -29,9 +29,16 @@ const ALLOWED_MINIMAX_MODELS = [
   'MiniMax-M2.5-highspeed',
 ] as const
 
+const ALLOWED_PROVIDERS = ['anthropic', 'openai', 'minimax', 'openai_compatible'] as const
+
 export async function GET(): Promise<NextResponse> {
   try {
-    const [anthropic, anthropicModel, provider, openai, openaiModel, minimax, minimaxModel, xClientId, xClientSecret, obsidianVault] = await Promise.all([
+    const [
+      anthropic, anthropicModel, provider, openai, openaiModel,
+      minimax, minimaxModel,
+      openaiCompatibleApiKey, openaiCompatibleBaseUrl, openaiCompatibleModel,
+      xClientId, xClientSecret, obsidianVault,
+    ] = await Promise.all([
       prisma.setting.findUnique({ where: { key: 'anthropicApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'anthropicModel' } }),
       prisma.setting.findUnique({ where: { key: 'aiProvider' } }),
@@ -39,6 +46,9 @@ export async function GET(): Promise<NextResponse> {
       prisma.setting.findUnique({ where: { key: 'openaiModel' } }),
       prisma.setting.findUnique({ where: { key: 'minimaxApiKey' } }),
       prisma.setting.findUnique({ where: { key: 'minimaxModel' } }),
+      prisma.setting.findUnique({ where: { key: 'openaiCompatibleApiKey' } }),
+      prisma.setting.findUnique({ where: { key: 'openaiCompatibleBaseUrl' } }),
+      prisma.setting.findUnique({ where: { key: 'openaiCompatibleModel' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_id' } }),
       prisma.setting.findUnique({ where: { key: 'x_oauth_client_secret' } }),
       prisma.setting.findUnique({ where: { key: 'obsidianVaultPath' } }),
@@ -55,6 +65,12 @@ export async function GET(): Promise<NextResponse> {
       minimaxApiKey: maskKey(minimax?.value ?? null),
       hasMinimaxKey: minimax !== null,
       minimaxModel: minimaxModel?.value ?? 'MiniMax-M2.7',
+      // OpenAI-compatible provider settings
+      openaiCompatibleApiKey: maskKey(openaiCompatibleApiKey?.value ?? null),
+      hasOpenaiCompatibleKey: !!openaiCompatibleApiKey?.value,
+      openaiCompatibleBaseUrl: openaiCompatibleBaseUrl?.value ?? '',
+      openaiCompatibleModel: openaiCompatibleModel?.value ?? '',
+      // X OAuth
       xOAuthClientId: maskKey(xClientId?.value ?? null),
       xOAuthClientSecret: maskKey(xClientSecret?.value ?? null),
       hasXOAuth: !!xClientId?.value,
@@ -78,6 +94,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     openaiModel?: string
     minimaxApiKey?: string
     minimaxModel?: string
+    openaiCompatibleApiKey?: string
+    openaiCompatibleBaseUrl?: string
+    openaiCompatibleModel?: string
     xOAuthClientId?: string
     xOAuthClientSecret?: string
     obsidianVaultPath?: string
@@ -88,11 +107,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const { anthropicApiKey, anthropicModel, provider, openaiApiKey, openaiModel, minimaxApiKey, minimaxModel } = body
+  const {
+    anthropicApiKey, anthropicModel, provider, openaiApiKey, openaiModel,
+    minimaxApiKey, minimaxModel,
+    openaiCompatibleApiKey, openaiCompatibleBaseUrl, openaiCompatibleModel,
+  } = body
 
   // Save provider if provided
   if (provider !== undefined) {
-    if (provider !== 'anthropic' && provider !== 'openai' && provider !== 'minimax') {
+    if (!(ALLOWED_PROVIDERS as readonly string[]).includes(provider)) {
       return NextResponse.json({ error: 'Invalid provider' }, { status: 400 })
     }
     await prisma.setting.upsert({
@@ -144,6 +167,68 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     })
     invalidateSettingsCache()
     return NextResponse.json({ saved: true })
+  }
+
+  // Save OpenAI-compatible model (free-form string, no allowlist)
+  if (openaiCompatibleModel !== undefined) {
+    const trimmed = openaiCompatibleModel.trim()
+    if (!trimmed) {
+      return NextResponse.json({ error: 'Model name cannot be empty' }, { status: 400 })
+    }
+    await prisma.setting.upsert({
+      where: { key: 'openaiCompatibleModel' },
+      update: { value: trimmed },
+      create: { key: 'openaiCompatibleModel', value: trimmed },
+    })
+    invalidateSettingsCache()
+    return NextResponse.json({ saved: true })
+  }
+
+  // Save OpenAI-compatible base URL
+  if (openaiCompatibleBaseUrl !== undefined) {
+    const trimmed = openaiCompatibleBaseUrl.trim()
+    if (!trimmed) {
+      return NextResponse.json({ error: 'Base URL cannot be empty' }, { status: 400 })
+    }
+    // Basic URL validation
+    try {
+      new URL(trimmed)
+    } catch {
+      return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 })
+    }
+    await prisma.setting.upsert({
+      where: { key: 'openaiCompatibleBaseUrl' },
+      update: { value: trimmed },
+      create: { key: 'openaiCompatibleBaseUrl', value: trimmed },
+    })
+    invalidateSettingsCache()
+    return NextResponse.json({ saved: true })
+  }
+
+  // Save OpenAI-compatible API key
+  if (openaiCompatibleApiKey !== undefined) {
+    const trimmed = openaiCompatibleApiKey.trim()
+    // Allow empty string to clear key (some local servers don't need one)
+    if (trimmed === '') {
+      await prisma.setting.deleteMany({ where: { key: 'openaiCompatibleApiKey' } })
+      invalidateSettingsCache()
+      return NextResponse.json({ saved: true })
+    }
+    try {
+      await prisma.setting.upsert({
+        where: { key: 'openaiCompatibleApiKey' },
+        update: { value: trimmed },
+        create: { key: 'openaiCompatibleApiKey', value: trimmed },
+      })
+      invalidateSettingsCache()
+      return NextResponse.json({ saved: true })
+    } catch (err) {
+      console.error('Settings POST (openai-compatible) error:', err)
+      return NextResponse.json(
+        { error: `Failed to save: ${err instanceof Error ? err.message : String(err)}` },
+        { status: 500 }
+      )
+    }
   }
 
   // Save Anthropic key if provided
@@ -272,7 +357,11 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const allowed = ['anthropicApiKey', 'openaiApiKey', 'minimaxApiKey', 'x_oauth_client_id', 'x_oauth_client_secret']
+  const allowed = [
+    'anthropicApiKey', 'openaiApiKey', 'minimaxApiKey',
+    'openaiCompatibleApiKey', 'openaiCompatibleBaseUrl', 'openaiCompatibleModel',
+    'x_oauth_client_id', 'x_oauth_client_secret',
+  ]
   if (!body.key || !allowed.includes(body.key)) {
     return NextResponse.json({ error: 'Invalid key' }, { status: 400 })
   }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -171,6 +171,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Save OpenAI-compatible model (free-form string, no allowlist)
   if (openaiCompatibleModel !== undefined) {
+    if (typeof openaiCompatibleModel !== 'string') {
+      return NextResponse.json({ error: 'Invalid openaiCompatibleModel value' }, { status: 400 })
+    }
     const trimmed = openaiCompatibleModel.trim()
     if (!trimmed) {
       return NextResponse.json({ error: 'Model name cannot be empty' }, { status: 400 })
@@ -186,6 +189,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Save OpenAI-compatible base URL
   if (openaiCompatibleBaseUrl !== undefined) {
+    if (typeof openaiCompatibleBaseUrl !== 'string') {
+      return NextResponse.json({ error: 'Invalid openaiCompatibleBaseUrl value' }, { status: 400 })
+    }
     const trimmed = openaiCompatibleBaseUrl.trim()
     if (!trimmed) {
       return NextResponse.json({ error: 'Base URL cannot be empty' }, { status: 400 })
@@ -207,6 +213,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Save OpenAI-compatible API key
   if (openaiCompatibleApiKey !== undefined) {
+    if (typeof openaiCompatibleApiKey !== 'string') {
+      return NextResponse.json({ error: 'Invalid openaiCompatibleApiKey value' }, { status: 400 })
+    }
     const trimmed = openaiCompatibleApiKey.trim()
     // Allow empty string to clear key (some local servers don't need one)
     if (trimmed === '') {

--- a/app/api/settings/test/route.ts
+++ b/app/api/settings/test/route.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/db'
 import { resolveAnthropicClient, getCliAuthStatus } from '@/lib/claude-cli-auth'
 import { resolveOpenAIClient } from '@/lib/openai-auth'
 import { resolveMiniMaxClient } from '@/lib/minimax-auth'
+import { resolveOpenAICompatibleClient } from '@/lib/openai-compatible-auth'
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   let body: { provider?: string } = {}
@@ -102,6 +103,46 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         : msg.includes('403')
         ? 'Key does not have permission'
         : msg.slice(0, 120)
+      return NextResponse.json({ working: false, error: friendly })
+    }
+  }
+
+  if (provider === 'openai_compatible') {
+    // Get the configured model name
+    const modelSetting = await prisma.setting.findUnique({ where: { key: 'openaiCompatibleModel' } })
+    const modelName = modelSetting?.value?.trim()
+    if (!modelName) {
+      return NextResponse.json({ working: false, error: 'No model name configured. Set a model name in Settings.' })
+    }
+
+    let client
+    try {
+      client = await resolveOpenAICompatibleClient()
+    } catch (e) {
+      return NextResponse.json({ working: false, error: e instanceof Error ? e.message : 'Failed to create client' })
+    }
+
+    try {
+      await client.chat.completions.create({
+        model: modelName,
+        max_tokens: 5,
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+      return NextResponse.json({ working: true })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      let friendly: string
+      if (msg.includes('ECONNREFUSED') || msg.includes('ENOTFOUND')) {
+        friendly = 'Cannot connect to endpoint. Is the server running?'
+      } else if (msg.includes('401') || msg.includes('invalid_api_key')) {
+        friendly = 'Invalid API key'
+      } else if (msg.includes('403')) {
+        friendly = 'Key does not have permission'
+      } else if (msg.includes('404')) {
+        friendly = 'Model not found. Check the model name and endpoint URL.'
+      } else {
+        friendly = msg.slice(0, 150)
+      }
       return NextResponse.json({ working: false, error: friendly })
     }
   }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -525,7 +525,7 @@ function CodexCliStatusBox() {
   )
 }
 
-function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai' | 'minimax'; onChange: (v: 'anthropic' | 'openai' | 'minimax') => void }) {
+function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai' | 'minimax' | 'openai_compatible'; onChange: (v: 'anthropic' | 'openai' | 'minimax' | 'openai_compatible') => void }) {
   return (
     <div className="flex items-center gap-1 p-1 rounded-xl bg-zinc-800 border border-zinc-700 mb-5">
       <button
@@ -562,22 +562,184 @@ function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai' | '
   )
 }
 
+
+function OpenAICompatibleSection({ onToast }: { onToast: (t: Toast) => void }) {
+  const [baseUrl, setBaseUrl] = useState('')
+  const [modelName, setModelName] = useState('')
+  const [savedBaseUrl, setSavedBaseUrl] = useState('')
+  const [savedModel, setSavedModel] = useState('')
+  const [saving, setSaving] = useState<string | null>(null)
+  const [testState, setTestState] = useState<'idle' | 'testing' | 'ok' | 'fail'>('idle')
+  const [testError, setTestError] = useState('')
+
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((d: { openaiCompatibleBaseUrl?: string; openaiCompatibleModel?: string; openaiCompatibleApiKey?: string }) => {
+        setSavedBaseUrl(d.openaiCompatibleBaseUrl ?? '')
+        setSavedModel(d.openaiCompatibleModel ?? '')
+        setBaseUrl(d.openaiCompatibleBaseUrl ?? '')
+        setModelName(d.openaiCompatibleModel ?? '')
+      })
+      .catch(() => {})
+  }, [])
+
+  async function saveField(key: string, value: string, label: string) {
+    setSaving(key)
+    try {
+      const res = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [key]: value }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error ?? 'Failed to save')
+      }
+      if (key === 'openaiCompatibleBaseUrl') setSavedBaseUrl(value)
+      if (key === 'openaiCompatibleModel') setSavedModel(value)
+      onToast({ type: 'success', message: `${label} saved` })
+    } catch (e) {
+      onToast({ type: 'error', message: e instanceof Error ? e.message : 'Failed to save' })
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  async function handleTest() {
+    setTestState('testing')
+    try {
+      const res = await fetch('/api/settings/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: 'openai_compatible' }),
+      })
+      const data = await res.json()
+      if (data.working) {
+        setTestState('ok')
+        onToast({ type: 'success', message: 'Connection working!' })
+      } else {
+        setTestState('fail')
+        setTestError(data.error ?? 'Unknown error')
+        onToast({ type: 'error', message: data.error ?? 'Connection test failed' })
+      }
+    } catch {
+      setTestState('fail')
+      setTestError('Network error')
+      onToast({ type: 'error', message: 'Network error during test' })
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="bg-zinc-800/50 border border-purple-500/20 rounded-xl p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Zap size={14} className="text-purple-400" />
+          <span className="text-sm font-medium text-purple-300">OpenAI-Compatible Endpoint</span>
+        </div>
+        <p className="text-xs text-zinc-400 leading-relaxed">
+          Connect any provider with an OpenAI-compatible API: <strong className="text-zinc-300">Ollama</strong>, <strong className="text-zinc-300">llama.cpp</strong>, <strong className="text-zinc-300">vLLM</strong>, <strong className="text-zinc-300">LM Studio</strong>, <strong className="text-zinc-300">Together AI</strong>, <strong className="text-zinc-300">Groq</strong>, <strong className="text-zinc-300">Deepseek</strong>, <strong className="text-zinc-300">Mistral</strong>, and more.
+        </p>
+      </div>
+
+      {/* Base URL */}
+      <div>
+        <label className="text-sm font-medium text-zinc-300 mb-1.5 block">Endpoint URL <span className="text-red-400">*</span></label>
+        <div className="flex gap-2">
+          <input
+            type="url"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder="http://localhost:11434/v1"
+            className="flex-1 bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-purple-500/50 transition-colors"
+          />
+          <button
+            onClick={() => void saveField('openaiCompatibleBaseUrl', baseUrl, 'Endpoint URL')}
+            disabled={!baseUrl.trim() || saving === 'openaiCompatibleBaseUrl'}
+            className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:hover:bg-purple-600 text-white text-sm rounded-lg font-medium transition-colors"
+          >
+            {saving === 'openaiCompatibleBaseUrl' ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+          </button>
+        </div>
+        <p className="text-xs text-zinc-500 mt-1.5">
+          Common endpoints: Ollama <code className="text-zinc-400 font-mono">localhost:11434/v1</code> · LM Studio <code className="text-zinc-400 font-mono">localhost:1234/v1</code> · vLLM <code className="text-zinc-400 font-mono">localhost:8000/v1</code>
+        </p>
+      </div>
+
+      {/* Model Name */}
+      <div>
+        <label className="text-sm font-medium text-zinc-300 mb-1.5 block">Model Name <span className="text-red-400">*</span></label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={modelName}
+            onChange={(e) => setModelName(e.target.value)}
+            placeholder="llama3.2, mistral, deepseek-r1..."
+            className="flex-1 bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-purple-500/50 transition-colors"
+          />
+          <button
+            onClick={() => void saveField('openaiCompatibleModel', modelName, 'Model')}
+            disabled={!modelName.trim() || saving === 'openaiCompatibleModel'}
+            className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 disabled:hover:bg-purple-600 text-white text-sm rounded-lg font-medium transition-colors"
+          >
+            {saving === 'openaiCompatibleModel' ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+          </button>
+        </div>
+        <p className="text-xs text-zinc-500 mt-1.5">The exact model identifier your endpoint expects (e.g., <code className="text-zinc-400 font-mono">llama3.2</code> for Ollama)</p>
+      </div>
+
+      {/* API Key (optional) */}
+      <ApiKeyField
+        label="API Key (optional)"
+        placeholder="Leave empty for local servers"
+        fieldKey="openaiCompatibleApiKey"
+        hint="Most local servers don't need an API key. Cloud providers (Together, Groq, etc.) do."
+        onToast={onToast}
+      />
+
+      {/* Test Connection */}
+      {savedBaseUrl && savedModel && (
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => void handleTest()}
+            disabled={testState === 'testing'}
+            className="px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 hover:border-zinc-600 text-zinc-300 text-sm rounded-lg font-medium transition-all flex items-center gap-2"
+          >
+            {testState === 'testing' ? (
+              <><Loader2 size={14} className="animate-spin" /> Testing...</>
+            ) : testState === 'ok' ? (
+              <><Check size={14} className="text-emerald-400" /> Connected</>
+            ) : testState === 'fail' ? (
+              <><AlertCircle size={14} className="text-red-400" /> Retry Test</>
+            ) : (
+              <><Zap size={14} /> Test Connection</>
+            )}
+          </button>
+          {testState === 'fail' && testError && (
+            <span className="text-xs text-red-400">{testError}</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
-  const [provider, setProvider] = useState<'anthropic' | 'openai' | 'minimax' | null>(null)
+  const [provider, setProvider] = useState<'anthropic' | 'openai' | 'minimax' | 'openai_compatible' | null>(null)
 
   useEffect(() => {
     fetch('/api/settings')
       .then((r) => r.json())
       .then((d: { provider?: string }) => {
-        setProvider(d.provider === 'openai' ? 'openai' : d.provider === 'minimax' ? 'minimax' : 'anthropic')
+        setProvider(d.provider === 'openai' ? 'openai' : d.provider === 'minimax' ? 'minimax' : d.provider === 'openai_compatible' ? 'openai_compatible' : 'anthropic')
       })
       .catch(() => setProvider('anthropic'))
   }, [])
 
-  async function handleProviderChange(newProvider: 'anthropic' | 'openai' | 'minimax') {
+  async function handleProviderChange(newProvider: 'anthropic' | 'openai' | 'minimax' | 'openai_compatible') {
     const prev = provider
     setProvider(newProvider)
-    const labels: Record<string, string> = { anthropic: 'Anthropic', openai: 'OpenAI', minimax: 'MiniMax' }
+    const labels: Record<string, string> = { anthropic: 'Anthropic', openai: 'OpenAI', minimax: 'MiniMax', openai_compatible: 'Custom (OpenAI-Compatible)' }
     try {
       const res = await fetch('/api/settings', {
         method: 'POST',
@@ -663,7 +825,7 @@ function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
             </div>
           </div>
         </>
-      ) : (
+      ) : provider === 'minimax' ? (
         <div className="space-y-5">
           <div>
             <ApiKeyField
@@ -684,6 +846,8 @@ function ApiKeySection({ onToast }: { onToast: (t: Toast) => void }) {
             <p className="text-xs text-zinc-500 mt-1.5">MiniMax M2.7 supports 1M context window — great for large batch categorization</p>
           </div>
         </div>
+      ) : (
+        <OpenAICompatibleSection onToast={onToast} />
       )}
       <p className="text-xs text-zinc-600 mt-4">Keys are stored in plaintext in your local SQLite database (<code className="font-mono">prisma/dev.db</code>). Do not expose the database file.</p>
     </Section>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -558,6 +558,16 @@ function ProviderToggle({ value, onChange }: { value: 'anthropic' | 'openai' | '
       >
         MiniMax
       </button>
+      <button
+        onClick={() => onChange('openai_compatible')}
+        className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+          value === 'openai_compatible'
+            ? 'bg-purple-600 text-white shadow-sm'
+            : 'text-zinc-400 hover:text-zinc-200'
+        }`}
+      >
+        Custom
+      </button>
     </div>
   )
 }

--- a/lib/ai-client.ts
+++ b/lib/ai-client.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai'
 import { resolveAnthropicClient } from './claude-cli-auth'
 import { resolveOpenAIClient } from './openai-auth'
 import { resolveMiniMaxClient } from './minimax-auth'
+import { resolveOpenAICompatibleClient } from './openai-compatible-auth'
 import { getProvider } from './settings'
 
 export interface AIContentBlock {
@@ -20,8 +21,10 @@ export interface AIResponse {
   text: string
 }
 
+export type AIProviderType = 'anthropic' | 'openai' | 'minimax' | 'openai_compatible'
+
 export interface AIClient {
-  provider: 'anthropic' | 'openai' | 'minimax'
+  provider: AIProviderType
   createMessage(params: {
     model: string
     max_tokens: number
@@ -137,11 +140,53 @@ export class MiniMaxAIClient implements AIClient {
   }
 }
 
+// Wrap any OpenAI-compatible API (Ollama, Together, Groq, vLLM, llama.cpp, LM Studio, etc.)
+export class OpenAICompatibleClient implements AIClient {
+  provider = 'openai_compatible' as const
+  constructor(private sdk: OpenAI) {}
+
+  async createMessage(params: { model: string; max_tokens: number; messages: AIMessage[] }): Promise<AIResponse> {
+    const messages: OpenAI.ChatCompletionMessageParam[] = params.messages.map((m): OpenAI.ChatCompletionMessageParam => {
+      if (typeof m.content === 'string') {
+        if (m.role === 'assistant') return { role: 'assistant' as const, content: m.content }
+        return { role: 'user' as const, content: m.content }
+      }
+      const parts: OpenAI.ChatCompletionContentPart[] = m.content.map(b => {
+        if (b.type === 'image' && b.source) {
+          return {
+            type: 'image_url' as const,
+            image_url: { url: `data:${b.source.media_type};base64,${b.source.data}` },
+          }
+        }
+        return { type: 'text' as const, text: b.text ?? '' }
+      })
+      if (m.role === 'assistant') return { role: 'assistant' as const, content: parts.filter((p): p is OpenAI.ChatCompletionContentPartText => p.type === 'text') }
+      return { role: 'user' as const, content: parts }
+    })
+
+    const completion = await this.sdk.chat.completions.create({
+      model: params.model,
+      max_tokens: params.max_tokens,
+      messages,
+    })
+
+    let text = completion.choices[0]?.message?.content ?? ''
+    // Strip thinking tags that some models may include
+    text = text.replace(/<think>[\s\S]*?<\/think>\s*/g, '')
+    return { text }
+  }
+}
+
 export async function resolveAIClient(options: {
   overrideKey?: string
   dbKey?: string
 } = {}): Promise<AIClient> {
   const provider = await getProvider()
+
+  if (provider === 'openai_compatible') {
+    const client = await resolveOpenAICompatibleClient(options)
+    return new OpenAICompatibleClient(client)
+  }
 
   if (provider === 'minimax') {
     const client = resolveMiniMaxClient(options)

--- a/lib/openai-compatible-auth.ts
+++ b/lib/openai-compatible-auth.ts
@@ -1,0 +1,66 @@
+import OpenAI from 'openai'
+import prisma from '@/lib/db'
+
+/**
+ * Resolve an OpenAI-compatible client for any provider that implements
+ * the OpenAI chat completions API.
+ *
+ * This covers:
+ *   - Local LLMs: Ollama (http://localhost:11434/v1), llama.cpp, vLLM, LM Studio
+ *   - Cloud APIs: Together AI, Groq, Fireworks, Anyscale, Deepseek, Mistral, etc.
+ *   - Self-hosted: text-generation-webui, LocalAI, etc.
+ *
+ * Auth priority:
+ *   1. Override key (from request body)
+ *   2. DB-saved key
+ *   3. OPENAI_COMPATIBLE_API_KEY env var
+ *   4. No key (for local servers that don't require auth)
+ *
+ * Base URL priority:
+ *   1. DB-saved base URL
+ *   2. OPENAI_COMPATIBLE_BASE_URL env var
+ *   3. Error (base URL is required for this provider)
+ */
+export async function resolveOpenAICompatibleClient(options: {
+  overrideKey?: string
+  dbKey?: string
+  baseURL?: string
+} = {}): Promise<OpenAI> {
+  // Resolve base URL
+  let baseURL = options.baseURL
+  if (!baseURL) {
+    const setting = await prisma.setting.findUnique({ where: { key: 'openaiCompatibleBaseUrl' } })
+    baseURL = setting?.value?.trim() || undefined
+  }
+  if (!baseURL) {
+    baseURL = process.env.OPENAI_COMPATIBLE_BASE_URL?.trim() || undefined
+  }
+  if (!baseURL) {
+    throw new Error(
+      'No base URL configured for OpenAI-compatible provider. ' +
+      'Set the endpoint URL in Settings (e.g., http://localhost:11434/v1 for Ollama).'
+    )
+  }
+
+  // Resolve API key (optional — many local servers don't need one)
+  let apiKey: string | undefined
+
+  if (options.overrideKey?.trim()) {
+    apiKey = options.overrideKey.trim()
+  } else if (options.dbKey?.trim()) {
+    apiKey = options.dbKey.trim()
+  } else {
+    const setting = await prisma.setting.findUnique({ where: { key: 'openaiCompatibleApiKey' } })
+    apiKey = setting?.value?.trim() || undefined
+  }
+
+  if (!apiKey) {
+    apiKey = process.env.OPENAI_COMPATIBLE_API_KEY?.trim() || undefined
+  }
+
+  // Use a placeholder key for servers that don't require auth (e.g., Ollama)
+  return new OpenAI({
+    apiKey: apiKey || 'not-needed',
+    baseURL,
+  })
+}

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,10 +1,12 @@
 import prisma from '@/lib/db'
 
+export type AIProviderType = 'anthropic' | 'openai' | 'minimax' | 'openai_compatible'
+
 // Module-level caches — avoids hundreds of DB roundtrips per pipeline run
 let _cachedModel: string | null = null
 let _modelCacheExpiry = 0
 
-let _cachedProvider: 'anthropic' | 'openai' | 'minimax' | null = null
+let _cachedProvider: AIProviderType | null = null
 let _providerCacheExpiry = 0
 
 let _cachedOpenAIModel: string | null = null
@@ -12,6 +14,9 @@ let _openAIModelCacheExpiry = 0
 
 let _cachedMiniMaxModel: string | null = null
 let _miniMaxModelCacheExpiry = 0
+
+let _cachedOpenAICompatibleModel: string | null = null
+let _openAICompatibleModelCacheExpiry = 0
 
 const CACHE_TTL = 5 * 60 * 1000
 
@@ -29,11 +34,14 @@ export async function getAnthropicModel(): Promise<string> {
 /**
  * Get the active AI provider (cached for 5 minutes).
  */
-export async function getProvider(): Promise<'anthropic' | 'openai' | 'minimax'> {
+export async function getProvider(): Promise<AIProviderType> {
   if (_cachedProvider && Date.now() < _providerCacheExpiry) return _cachedProvider
   const setting = await prisma.setting.findUnique({ where: { key: 'aiProvider' } })
   const val = setting?.value
-  _cachedProvider = val === 'openai' ? 'openai' : val === 'minimax' ? 'minimax' : 'anthropic'
+  if (val === 'openai') _cachedProvider = 'openai'
+  else if (val === 'minimax') _cachedProvider = 'minimax'
+  else if (val === 'openai_compatible') _cachedProvider = 'openai_compatible'
+  else _cachedProvider = 'anthropic'
   _providerCacheExpiry = Date.now() + CACHE_TTL
   return _cachedProvider
 }
@@ -61,10 +69,23 @@ export async function getMiniMaxModel(): Promise<string> {
 }
 
 /**
+ * Get the configured OpenAI-compatible model from settings (cached for 5 minutes).
+ * This is a free-form string since the model depends on the endpoint.
+ */
+export async function getOpenAICompatibleModel(): Promise<string> {
+  if (_cachedOpenAICompatibleModel && Date.now() < _openAICompatibleModelCacheExpiry) return _cachedOpenAICompatibleModel
+  const setting = await prisma.setting.findUnique({ where: { key: 'openaiCompatibleModel' } })
+  _cachedOpenAICompatibleModel = setting?.value ?? ''
+  _openAICompatibleModelCacheExpiry = Date.now() + CACHE_TTL
+  return _cachedOpenAICompatibleModel
+}
+
+/**
  * Get the model for the currently active provider.
  */
 export async function getActiveModel(): Promise<string> {
   const provider = await getProvider()
+  if (provider === 'openai_compatible') return getOpenAICompatibleModel()
   if (provider === 'minimax') return getMiniMaxModel()
   return provider === 'openai' ? getOpenAIModel() : getAnthropicModel()
 }
@@ -81,4 +102,6 @@ export function invalidateSettingsCache(): void {
   _openAIModelCacheExpiry = 0
   _cachedMiniMaxModel = null
   _miniMaxModelCacheExpiry = 0
+  _cachedOpenAICompatibleModel = null
+  _openAICompatibleModelCacheExpiry = 0
 }


### PR DESCRIPTION
Add a new 'Custom (OpenAI-Compatible)' provider option that supports any service implementing the OpenAI chat completions API:

- Local LLMs: Ollama, llama.cpp, vLLM, LM Studio, LocalAI
- Cloud APIs: Together AI, Groq, Fireworks, Deepseek, Mistral, etc.

Changes:
- lib/openai-compatible-auth.ts: New auth module (flexible base URL, optional API key)
- lib/ai-client.ts: OpenAICompatibleClient class, updated AIProviderType
- lib/settings.ts: New provider type, free-form model getter
- app/api/settings/route.ts: CRUD for base URL, model name, API key
- app/api/settings/test/route.ts: Connection test with friendly errors
- app/settings/page.tsx: New provider tab with config UI and test button
- .env.example: Documented new env vars with common endpoint examples

## Summary
<!-- Brief description of what this PR does -->

## Changes
-

## Related Issues
<!-- Fixes #123, Closes #456 -->

## Checklist
- [ ] Tested locally
- [ ] `npx tsc --noEmit` passes
- [ ] No new warnings
