### PR TITLE
fix(x-oauth): honor reverse-proxy headers when building redirect_uri

### DIFF
--- a/app/api/import/x-oauth/authorize/route.ts
+++ b/app/api/import/x-oauth/authorize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db'
 import crypto from 'crypto'
+import { getPublicOrigin } from '@/lib/public-origin'
 
 export async function GET(req: NextRequest) {
   const clientId = await prisma.setting.findUnique({ where: { key: 'x_oauth_client_id' } })
@@ -20,8 +21,10 @@ export async function GET(req: NextRequest) {
   await prisma.setting.upsert({ where: { key: 'x_oauth_code_verifier' }, create: { key: 'x_oauth_code_verifier', value: codeVerifier }, update: { value: codeVerifier } })
   await prisma.setting.upsert({ where: { key: 'x_oauth_state' }, create: { key: 'x_oauth_state', value: state }, update: { value: state } })
 
-  // Store the origin so the callback can use it too
-  const origin = `${req.nextUrl.protocol}//${req.nextUrl.host}`
+  // Store the origin so the callback can use it too. Honor reverse-proxy headers
+  // so the redirect_uri matches what the user sees in the browser (and what's
+  // registered in the X Developer Portal) — not the internal container address.
+  const origin = getPublicOrigin(req)
   await prisma.setting.upsert({ where: { key: 'x_oauth_redirect_origin' }, create: { key: 'x_oauth_redirect_origin', value: origin }, update: { value: origin } })
   const redirectUri = `${origin}/api/import/x-oauth/callback`
 

--- a/app/api/import/x-oauth/callback/route.ts
+++ b/app/api/import/x-oauth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db'
+import { getPublicOrigin } from '@/lib/public-origin'
 
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl
@@ -7,7 +8,7 @@ export async function GET(req: NextRequest) {
   const state = searchParams.get('state')
   const error = searchParams.get('error')
   const savedOrigin = await prisma.setting.findUnique({ where: { key: 'x_oauth_redirect_origin' } })
-  const baseUrl = savedOrigin?.value ?? `${req.nextUrl.protocol}//${req.nextUrl.host}`
+  const baseUrl = savedOrigin?.value ?? getPublicOrigin(req)
   const importPage = `${baseUrl}/import`
 
   if (error) {
@@ -31,7 +32,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(`${importPage}?x_error=missing_config`)
   }
 
-  const redirectUri = `${savedOrigin?.value ?? baseUrl}/api/import/x-oauth/callback`
+  const redirectUri = `${baseUrl}/api/import/x-oauth/callback`
 
   // Exchange code for tokens
   const tokenBody = new URLSearchParams({

--- a/lib/public-origin.ts
+++ b/lib/public-origin.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from 'next/server'
+
+/**
+ * Resolve the externally-visible origin for the current request.
+ *
+ * When Siftly is deployed behind a reverse proxy (Cloudflare Tunnel, nginx, Caddy, Traefik),
+ * `req.nextUrl.protocol`/`host` reflect the internal listener (e.g. `http://siftly:3000`),
+ * which produces wrong OAuth `redirect_uri` values. This helper prefers, in order:
+ *   1. `PUBLIC_BASE_URL` env var (explicit override)
+ *   2. `Forwarded` header (RFC 7239)
+ *   3. `X-Forwarded-Proto` + `X-Forwarded-Host`
+ *   4. `req.nextUrl` (direct hit, no proxy)
+ */
+export function getPublicOrigin(req: NextRequest): string {
+  const override = process.env.PUBLIC_BASE_URL?.trim()
+  if (override) return override.replace(/\/+$/, '')
+
+  const forwarded = req.headers.get('forwarded')
+  if (forwarded) {
+    const protoMatch = forwarded.match(/proto=([^;,\s]+)/i)
+    const hostMatch = forwarded.match(/host=([^;,\s]+)/i)
+    const proto = protoMatch?.[1]?.replace(/"/g, '')
+    const host = hostMatch?.[1]?.replace(/"/g, '')
+    if (proto && host) return `${proto}://${host}`
+  }
+
+  const xfProto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim()
+  const xfHost = req.headers.get('x-forwarded-host')?.split(',')[0]?.trim()
+    ?? req.headers.get('host')
+  if (xfProto && xfHost) return `${xfProto}://${xfHost}`
+
+  const protocol = req.nextUrl.protocol.replace(/:$/, '')
+  return `${protocol}://${req.nextUrl.host}`
+}


### PR DESCRIPTION
## Summary

When Siftly runs behind a reverse proxy (Cloudflare Tunnel, nginx, Caddy, Traefik, etc.), the OAuth `redirect_uri` is currently built from `req.nextUrl.protocol`/`host`, which reflects the **internal** container listener (e.g. `http://localhost:3000`) — not the public URL the user sees. The result: the X authorize URL ends up looking like

\`\`\`
https://x.com/i/oauth2/authorize?...&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fapi%2Fimport%2Fx-oauth%2Fcallback&...
\`\`\`

…and the user has to either register \`localhost:3000\` in the X Developer Portal (which is wrong) or hit \`redirect_uri_mismatch\`.

## Fix

New helper \`lib/public-origin.ts\` resolves the public origin by checking, in order:

1. \`PUBLIC_BASE_URL\` env var (explicit override for ambiguous setups)
2. RFC 7239 \`Forwarded\` header
3. \`X-Forwarded-Proto\` + \`X-Forwarded-Host\` (Cloudflare Tunnel / nginx / Caddy / Traefik all set this by default)
4. \`req.nextUrl\` as a last-resort fallback (direct hit, no proxy)

Both \`/api/import/x-oauth/authorize\` and \`/api/import/x-oauth/callback\` now use it, so the \`redirect_uri\` always matches what the user sees in the browser and what's registered in the X Developer Portal.

## Test plan

- [x] Direct \`localhost\` flow still works (falls through to \`req.nextUrl\`)
- [ ] Behind Cloudflare Tunnel: authorize URL now contains the public hostname (verified locally via header injection)
- [ ] Token exchange in callback uses same public origin
- [ ] \`PUBLIC_BASE_URL\` override wins when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)