### PR TITLE
feat: URL import, per-category Obsidian export, and category organizer script

### DIFF
--- a/app/api/import/url/route.ts
+++ b/app/api/import/url/route.ts
@@ -1,0 +1,251 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/db'
+import { seedDefaultCategories, categorizeBatch, mapBookmarkForCategorization, writeCategoryResults } from '@/lib/categorizer'
+import { backfillEntities } from '@/lib/rawjson-extractor'
+import { enrichBatchSemanticTags, analyzeItem, BookmarkForEnrichment } from '@/lib/vision-analyzer'
+import { AIClient, resolveAIClient } from '@/lib/ai-client'
+import { getProvider } from '@/lib/settings'
+import { exportBookmarksByCategoryToObsidian } from '@/lib/obsidian-exporter'
+import { rebuildFts } from '@/lib/fts'
+
+// ── Twitter oEmbed fetcher ─────────────────────────────────────────────────────
+
+const TWEET_URL_RE = /(?:twitter\.com|x\.com)\/[^/]+\/status\/(\d{10,20})/i
+
+function extractTweetId(url: string): string | null {
+  const m = url.match(TWEET_URL_RE)
+  return m ? m[1] : null
+}
+
+interface OEmbedResponse {
+  html?: string
+  author_name?: string
+  author_url?: string
+  url?: string
+}
+
+async function fetchTweetData(url: string): Promise<{
+  tweetId: string
+  text: string
+  authorHandle: string
+  authorName: string
+  tweetCreatedAt: Date | null
+} | null> {
+  const tweetId = extractTweetId(url)
+  if (!tweetId) return null
+
+  try {
+    const oembed = await fetch(
+      `https://publish.twitter.com/oembed?url=${encodeURIComponent(url)}&omit_script=1&dnt=1`,
+      { signal: AbortSignal.timeout(8000) },
+    )
+    if (!oembed.ok) return null
+    const data: OEmbedResponse = await oembed.json()
+
+    // Extract text from HTML blockquote
+    const pMatch = data.html?.match(/<p[^>]*>([\s\S]*?)<\/p>/i)
+    let text = pMatch ? pMatch[1] : ''
+    // Strip HTML tags
+    text = text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+    // Decode common HTML entities
+    text = text
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&mdash;/g, '—')
+      .replace(/&hellip;/g, '…')
+
+    // Extract handle from author_url (last path segment)
+    const authorHandle = data.author_url?.split('/').pop()?.replace(/^@/, '') ?? 'unknown'
+    const authorName = data.author_name ?? authorHandle
+
+    // Try to parse date from the HTML href (timestamp link at end of blockquote)
+    let tweetCreatedAt: Date | null = null
+    const dateMatch = data.html?.match(/href="[^"]+\/status\/\d+">([^<]+)<\/a>/)
+    if (dateMatch) {
+      const parsed = new Date(dateMatch[1])
+      if (!isNaN(parsed.getTime())) tweetCreatedAt = parsed
+    }
+
+    return { tweetId, text, authorHandle, authorName, tweetCreatedAt }
+  } catch {
+    return null
+  }
+}
+
+// ── Handler ────────────────────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: { urls?: string[]; vaultPath?: string; exportToObsidian?: boolean } = {}
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { urls = [], vaultPath, exportToObsidian: shouldExport = false } = body
+
+  // Validate input
+  if (!Array.isArray(urls) || urls.length === 0) {
+    return NextResponse.json({ error: 'urls array is required and must be non-empty' }, { status: 400 })
+  }
+  if (urls.length > 100) {
+    return NextResponse.json({ error: 'Maximum 100 URLs per request' }, { status: 400 })
+  }
+
+  // Sanitise and validate each URL
+  const sanitizedUrls: string[] = []
+  const invalidUrls: string[] = []
+  for (const raw of urls) {
+    if (typeof raw !== 'string') { invalidUrls.push(String(raw)); continue }
+    const trimmed = raw.trim()
+    if (!TWEET_URL_RE.test(trimmed)) { invalidUrls.push(trimmed); continue }
+    if (!trimmed.startsWith('https://') && !trimmed.startsWith('http://')) {
+      invalidUrls.push(trimmed); continue
+    }
+    sanitizedUrls.push(trimmed)
+  }
+
+  // ── Step 1: Fetch tweet data ──────────────────────────────────────────────
+  const fetched: Awaited<ReturnType<typeof fetchTweetData>>[] = await Promise.all(
+    sanitizedUrls.map((url) => fetchTweetData(url)),
+  )
+
+  const valid = fetched.filter((t): t is NonNullable<typeof t> => t !== null)
+  const fetchFailed = sanitizedUrls.length - valid.length
+
+  // ── Step 2: Import into DB (skip duplicates) ──────────────────────────────
+  const importedIds: string[] = []
+  let skipped = 0
+
+  for (const tweet of valid) {
+    const existing = await prisma.bookmark.findUnique({
+      where: { tweetId: tweet.tweetId },
+      select: { id: true },
+    })
+    if (existing) { skipped++; continue }
+
+    const created = await prisma.bookmark.create({
+      data: {
+        tweetId: tweet.tweetId,
+        text: tweet.text,
+        authorHandle: tweet.authorHandle,
+        authorName: tweet.authorName,
+        tweetCreatedAt: tweet.tweetCreatedAt,
+        rawJson: JSON.stringify({ id: tweet.tweetId, text: tweet.text }),
+        source: 'bookmark',
+      },
+    })
+    importedIds.push(created.id)
+  }
+
+  if (importedIds.length === 0) {
+    return NextResponse.json({
+      imported: 0,
+      skipped,
+      fetchFailed,
+      invalidUrls,
+      categorized: 0,
+      exported: null,
+      message: skipped > 0 ? 'All URLs already in library.' : 'No tweets could be fetched.',
+    })
+  }
+
+  // ── Step 3: Entity extraction ─────────────────────────────────────────────
+  // backfillEntities processes all bookmarks with entities: null (our new ones qualify)
+  await backfillEntities()
+
+  // ── Step 4: Semantic tag enrichment ──────────────────────────────────────
+  await seedDefaultCategories()
+  const provider = await getProvider()
+  const keyName = provider === 'openai' ? 'openaiApiKey' : 'anthropicApiKey'
+  const apiKeySetting = await prisma.setting.findUnique({ where: { key: keyName } })
+  let client: AIClient | null = null
+  try {
+    client = await resolveAIClient({ dbKey: apiKeySetting?.value })
+  } catch { /* CLI will be used if available */ }
+
+  const model = await (await import('@/lib/settings')).getActiveModel()
+
+  // Vision analysis for any media
+  const mediaItems = await prisma.mediaItem.findMany({
+    where: {
+      bookmarkId: { in: importedIds },
+      imageTags: null,
+      type: { in: ['photo', 'gif', 'video'] },
+    },
+    select: { id: true, url: true, thumbnailUrl: true, type: true },
+  })
+  for (const item of mediaItems) {
+    await analyzeItem(item, client, model).catch(() => {})
+  }
+
+  // Semantic tags
+  const toEnrich = await prisma.bookmark.findMany({
+    where: { id: { in: importedIds } },
+    select: {
+      id: true, tweetId: true, text: true, semanticTags: true,
+      entities: true, mediaItems: { select: { imageTags: true } },
+    },
+  })
+  if (toEnrich.length > 0) {
+    const enrichInput: BookmarkForEnrichment[] = toEnrich.map((b) => {
+      let parsedEntities: BookmarkForEnrichment['entities'] = {}
+      try { parsedEntities = JSON.parse(b.entities ?? '{}') } catch {}
+      const imageTags = b.mediaItems
+        .map((m) => m.imageTags)
+        .filter((t): t is string => Boolean(t) && t !== '{}')
+      return { id: b.id, text: b.text, imageTags, entities: parsedEntities }
+    })
+    await enrichBatchSemanticTags(enrichInput, client).catch(() => {})
+  }
+
+  // ── Step 5: Categorize ────────────────────────────────────────────────────
+  const toCategory = await prisma.bookmark.findMany({
+    where: { id: { in: importedIds } },
+    select: {
+      id: true, tweetId: true, text: true, semanticTags: true,
+      entities: true, mediaItems: { select: { imageTags: true } },
+    },
+  })
+
+  const dbCategories = await prisma.category.findMany({ select: { slug: true, name: true, description: true } })
+  const allSlugs = dbCategories.map((c) => c.slug)
+  const categoryDescriptions = Object.fromEntries(
+    dbCategories.map((c) => [c.slug, c.description?.trim() ?? c.name]),
+  )
+
+  const mapped = toCategory.map((b) => mapBookmarkForCategorization(b))
+  const results = await categorizeBatch(mapped, client, categoryDescriptions, allSlugs)
+  await writeCategoryResults(results)
+
+  await rebuildFts().catch(() => {})
+
+  // ── Step 6: Optional Obsidian export ────────────────────────────────────
+  let exportResult: {written: number; errors: number; categories: string[]} | null = null
+
+  if (shouldExport) {
+    const resolvedVaultPath = vaultPath ??
+      (await prisma.setting.findUnique({ where: { key: 'obsidianVaultPath' } }))?.value
+
+    if (resolvedVaultPath) {
+      try {
+        exportResult = await exportBookmarksByCategoryToObsidian(importedIds, resolvedVaultPath)
+      } catch (err) {
+        exportResult = { written: 0, errors: 1, categories: [] }
+        console.error('[import/url] Obsidian export error:', err)
+      }
+    }
+  }
+
+  return NextResponse.json({
+    imported: importedIds.length,
+    skipped,
+    fetchFailed,
+    invalidUrls,
+    categorized: results.length,
+    exported: exportResult,
+  })
+}

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react'
 import Link from 'next/link'
-import { Upload, CheckCircle, ChevronRight, Loader2, Copy, Check, ExternalLink, Sparkles, Eye, Tag, Brain, Layers, StopCircle, RefreshCw, Clock, KeyRound, Trash2, AlertCircle, User, LogOut } from 'lucide-react'
+import { Upload, CheckCircle, ChevronRight, Loader2, Copy, Check, ExternalLink, Sparkles, Eye, Tag, Brain, Layers, StopCircle, RefreshCw, Clock, KeyRound, Trash2, AlertCircle, User, LogOut, Link2, FolderOutput } from 'lucide-react'
 import * as Progress from '@radix-ui/react-progress'
 
 type Step = 1 | 2 | 3
-type Method = 'bookmarklet' | 'console' | 'live'
+type Method = 'bookmarklet' | 'console' | 'live' | 'urls'
 
 interface ImportResult {
   imported: number
@@ -861,54 +861,227 @@ function LiveImportTab({ onSynced }: { onSynced: (result: ImportResult) => void 
   )
 }
 
+// ── URL Import Tab ───────────────────────────────────────────────────────────
+
+interface UrlImportResult {
+  imported: number
+  skipped: number
+  fetchFailed: number
+  invalidUrls: string[]
+  categorized: number
+  exported: { written: number; errors: number; categories: string[] } | null
+  message?: string
+}
+
+function UrlImportTab() {
+  const [urls, setUrls] = useState('')
+  const [vaultPath, setVaultPath] = useState('')
+  const [exportToObsidian, setExportToObsidian] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<UrlImportResult | null>(null)
+  const [error, setError] = useState('')
+
+  // Pre-fill vault path from settings
+  useEffect(() => {
+    fetch('/api/settings')
+      .then((r) => r.json())
+      .then((d: Record<string, unknown>) => {
+        const vp = typeof d.obsidianVaultPath === 'string' ? d.obsidianVaultPath : ''
+        if (vp) setVaultPath(vp)
+      })
+      .catch(() => {})
+  }, [])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    setResult(null)
+    setLoading(true)
+
+    const urlList = urls
+      .split(/[\n,]+/)
+      .map((u) => u.trim())
+      .filter(Boolean)
+
+    if (urlList.length === 0) {
+      setError('Paste at least one tweet URL.')
+      setLoading(false)
+      return
+    }
+
+    try {
+      const res = await fetch('/api/import/url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          urls: urlList,
+          exportToObsidian,
+          vaultPath: exportToObsidian ? vaultPath : undefined,
+        }),
+      })
+      const data: UrlImportResult = await res.json()
+      if (!res.ok) throw new Error((data as unknown as { error?: string }).error ?? 'Import failed')
+      setResult(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <p className="text-xs text-zinc-500">
+        Paste tweet URLs (one per line or comma-separated). Siftly fetches each tweet,
+        imports it, runs AI categorization, and optionally exports it to your Obsidian
+        vault organized by category.
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-xs font-medium text-zinc-400 mb-1.5">Tweet URLs</label>
+          <textarea
+            className="w-full h-36 px-3 py-2 text-xs font-mono bg-zinc-800 border border-zinc-700 rounded-xl text-zinc-200 placeholder-zinc-600 resize-none focus:outline-none focus:border-indigo-500"
+            placeholder="https://x.com/user/status/123...&#10;https://twitter.com/other/status/456..."
+            value={urls}
+            onChange={(e) => setUrls(e.target.value)}
+            disabled={loading}
+          />
+        </div>
+
+        {/* Obsidian export toggle */}
+        <div className="p-4 rounded-xl bg-zinc-800/60 border border-zinc-700/50 space-y-3">
+          <label className="flex items-center gap-3 cursor-pointer select-none">
+            <div
+              onClick={() => setExportToObsidian((v) => !v)}
+              className={`w-9 h-5 rounded-full relative transition-colors cursor-pointer ${
+                exportToObsidian ? 'bg-indigo-600' : 'bg-zinc-700'
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                  exportToObsidian ? 'translate-x-4' : 'translate-x-0'
+                }`}
+              />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-zinc-300 flex items-center gap-1.5">
+                <FolderOutput size={14} className="text-indigo-400" />
+                Export to Obsidian by category
+              </p>
+              <p className="text-xs text-zinc-500 mt-0.5">
+                Writes notes into <code className="text-zinc-400">Twitter Bookmarks/Category Name/</code>
+              </p>
+            </div>
+          </label>
+
+          {exportToObsidian && (
+            <div>
+              <label className="block text-xs font-medium text-zinc-400 mb-1">Vault path</label>
+              <input
+                type="text"
+                className="w-full px-3 py-2 text-xs font-mono bg-zinc-900 border border-zinc-700 rounded-lg text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-indigo-500"
+                placeholder="/Users/you/Documents/MyVault"
+                value={vaultPath}
+                onChange={(e) => setVaultPath(e.target.value)}
+                disabled={loading}
+              />
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors"
+        >
+          {loading ? (
+            <><Loader2 size={15} className="animate-spin" /> Processing…</>
+          ) : (
+            <><Link2 size={15} /> Import from URLs</>
+          )}
+        </button>
+      </form>
+
+      {result && (
+        <div className="rounded-xl border border-zinc-700 bg-zinc-800/40 p-4 space-y-2">
+          <p className="text-sm font-semibold text-zinc-200 flex items-center gap-2">
+            <CheckCircle size={15} className="text-emerald-400" /> Done
+          </p>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <span className="text-zinc-400">Imported</span>
+            <span className="text-emerald-400 font-semibold">{result.imported}</span>
+            <span className="text-zinc-400">Skipped (already in library)</span>
+            <span className="text-zinc-500">{result.skipped}</span>
+            {result.fetchFailed > 0 && (
+              <><span className="text-zinc-400">Failed to fetch</span>
+              <span className="text-amber-400">{result.fetchFailed}</span></>
+            )}
+            <span className="text-zinc-400">Categorized</span>
+            <span className="text-indigo-400">{result.categorized}</span>
+            {result.exported && (
+              <><span className="text-zinc-400">Exported to Obsidian</span>
+              <span className="text-teal-400">{result.exported.written} notes</span></>
+            )}
+          </div>
+          {result.exported?.categories && result.exported.categories.length > 0 && (
+            <p className="text-xs text-zinc-500 pt-1">
+              Categories: {result.exported.categories.join(', ')}
+            </p>
+          )}
+          {result.invalidUrls.length > 0 && (
+            <p className="text-xs text-amber-500/80 pt-1">
+              Skipped invalid URLs: {result.invalidUrls.slice(0, 3).join(', ')}{result.invalidUrls.length > 3 ? ` +${result.invalidUrls.length - 3} more` : ''}
+            </p>
+          )}
+          {result.message && (
+            <p className="text-xs text-zinc-500">{result.message}</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function InstructionsStep({ onFile, importSource, onLiveSynced }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like'; onLiveSynced: (result: ImportResult) => void }) {
-  const [method, setMethod] = useState<Method>('bookmarklet')
+  const [method, setMethod] = useState<Method>('live')
+
+  const TAB_DEFS: { key: Method; label: React.ReactNode }[] = [
+    { key: 'live', label: <><RefreshCw size={12} className="inline -mt-0.5 mr-1" />Live <span className="text-indigo-400 text-[10px] font-normal ml-1">Recommended</span></> },
+    { key: 'urls', label: <><Link2 size={12} className="inline -mt-0.5 mr-1" />From URLs</> },
+    { key: 'bookmarklet', label: 'Bookmarklet' },
+    { key: 'console', label: '</> Console' },
+  ]
 
   return (
     <div>
       {/* Method tabs */}
-      <div className="flex gap-1 mb-6 p-1 bg-zinc-800 rounded-xl">
-        <button
-          onClick={() => setMethod('live')}
-          className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
-            method === 'live'
-              ? 'bg-zinc-900 text-zinc-100 shadow-sm'
-              : 'text-zinc-500 hover:text-zinc-300'
-          }`}
-        >
-          <RefreshCw size={13} className="inline -mt-0.5 mr-1" />
-          Live Import
-          <span className="ml-1.5 text-xs text-indigo-400 font-normal">Recommended</span>
-        </button>
-        <button
-          onClick={() => setMethod('bookmarklet')}
-          className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
-            method === 'bookmarklet'
-              ? 'bg-zinc-900 text-zinc-100 shadow-sm'
-              : 'text-zinc-500 hover:text-zinc-300'
-          }`}
-        >
-          Bookmarklet
-        </button>
-        <button
-          onClick={() => setMethod('console')}
-          className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
-            method === 'console'
-              ? 'bg-zinc-900 text-zinc-100 shadow-sm'
-              : 'text-zinc-500 hover:text-zinc-300'
-          }`}
-        >
-          {'</>'} Console
-        </button>
+      <div className="flex gap-1 mb-6 p-1 bg-zinc-800 rounded-xl overflow-x-auto">
+        {TAB_DEFS.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setMethod(key)}
+            className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap ${
+              method === key
+                ? 'bg-zinc-900 text-zinc-100 shadow-sm'
+                : 'text-zinc-500 hover:text-zinc-300'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
       </div>
 
-      {method === 'live' ? (
-        <LiveImportTab onSynced={onLiveSynced} />
-      ) : method === 'bookmarklet' ? (
-        <BookmarkletTab onFile={onFile} importSource={importSource} />
-      ) : (
-        <ConsoleTab onFile={onFile} importSource={importSource} />
-      )}
+      {method === 'live' && <LiveImportTab onSynced={onLiveSynced} />}
+      {method === 'urls' && <UrlImportTab />}
+      {method === 'bookmarklet' && <BookmarkletTab onFile={onFile} importSource={importSource} />}
+      {method === 'console' && <ConsoleTab onFile={onFile} importSource={importSource} />}
     </div>
   )
 }

--- a/lib/obsidian-exporter.ts
+++ b/lib/obsidian-exporter.ts
@@ -202,6 +202,71 @@ function buildAuthorIndex(
   ].join('\n')
 }
 
+/**
+ * Export a specific set of bookmarks (by DB id) to an Obsidian vault,
+ * placing each note inside a subfolder named after its primary category.
+ * If a bookmark has multiple categories, it is placed in the first (highest-
+ * confidence) one and symlinked from the rest.
+ *
+ * Created directories: {vaultPath}/Twitter Bookmarks/{Category Name}/note.md
+ */
+export async function exportBookmarksByCategoryToObsidian(
+  bookmarkIds: string[],
+  vaultPath: string,
+  subfolder = 'Twitter Bookmarks',
+): Promise<{ written: number; errors: number; categories: string[] }> {
+  const validation = await validateVaultPath(vaultPath)
+  if (!validation.valid) throw new Error(`Invalid vault path: ${validation.error}`)
+
+  const safeSubfolder = sanitizeFilename(subfolder)
+  const baseDir = path.join(vaultPath, safeSubfolder)
+  const resolvedBase = path.resolve(baseDir)
+  const resolvedVault = path.resolve(vaultPath)
+  if (!resolvedBase.startsWith(resolvedVault + '/') && resolvedBase !== resolvedVault) {
+    throw new Error('Subfolder path escapes vault directory')
+  }
+
+  const bookmarks = await prisma.bookmark.findMany({
+    where: { id: { in: bookmarkIds } },
+    include: {
+      mediaItems: true,
+      categories: { include: { category: true }, orderBy: { confidence: 'desc' } },
+    },
+    orderBy: { tweetCreatedAt: 'desc' },
+  }) as BookmarkRow[]
+
+  let written = 0
+  let errors = 0
+  const usedCategories = new Set<string>()
+
+  for (const bookmark of bookmarks) {
+    // Determine primary category (highest confidence or fallback)
+    const primaryCategory =
+      bookmark.categories[0]?.category.name ?? 'General'
+    const catDir = path.join(baseDir, sanitizeFilename(primaryCategory))
+    const resolvedCatDir = path.resolve(catDir)
+
+    // Security: ensure category dir stays under baseDir
+    if (!resolvedCatDir.startsWith(resolvedBase + '/') && resolvedCatDir !== resolvedBase) continue
+
+    await fs.mkdir(catDir, { recursive: true })
+    usedCategories.add(primaryCategory)
+
+    const filename = noteFilename(bookmark)
+    const filePath = path.join(catDir, filename)
+
+    try {
+      await fs.writeFile(filePath, buildNoteMarkdown(bookmark), 'utf-8')
+      written++
+    } catch (err) {
+      console.error(`[obsidian] Failed to write ${filename}:`, err)
+      errors++
+    }
+  }
+
+  return { written, errors, categories: Array.from(usedCategories) }
+}
+
 export async function exportToObsidian(options: ObsidianExportOptions): Promise<ObsidianExportResult> {
   const { vaultPath, subfolder = 'Twitter Bookmarks', overwrite = false, categoryFilter } = options
 

--- a/scripts/organize-by-category.py
+++ b/scripts/organize-by-category.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+organize-by-category.py
+=======================
+Organises a flat Siftly Obsidian export into per-category subdirectories.
+
+Usage:
+    python scripts/organize-by-category.py /path/to/export/dir
+    python scripts/organize-by-category.py /path/to/export/dir --copy   # keep originals
+    python scripts/organize-by-category.py /path/to/export/dir --dry-run
+
+For bookmarks that belong to multiple categories the note is copied into each
+one. When moving (default) only one copy is kept and symlinks are used for the
+rest so the file exists in every relevant folder without duplication.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+# ── Frontmatter parsing ───────────────────────────────────────────────────────
+
+FRONT_DELIM = re.compile(r"^---\s*$", re.MULTILINE)
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Return a dict with frontmatter values. Returns {} on any parse error."""
+    parts = FRONT_DELIM.split(text, maxsplit=2)
+    if len(parts) < 3:
+        return {}
+    fm_block = parts[1]
+    result: dict = {}
+    # Minimal YAML parser — handles scalars and YAML flow/block sequences
+    # We only need: categories, tweet_id, author, date
+    list_key: str | None = None
+    list_items: list[str] = []
+    for line in fm_block.splitlines():
+        if not line.strip():
+            continue
+        # Item in a block sequence  (-  value  or  - "value")
+        item_m = re.match(r"^\s+-\s+(.*)", line)
+        if item_m and list_key:
+            val = item_m.group(1).strip().strip('"').strip("'")
+            list_items.append(val)
+            continue
+        # A new key — flush pending list
+        if list_key and list_items:
+            result[list_key] = list_items
+            list_key = None
+            list_items = []
+        kv_m = re.match(r'^(\w[\w_-]*):\s*(.*)', line)
+        if not kv_m:
+            continue
+        key, val = kv_m.group(1), kv_m.group(2).strip()
+        # Inline flow sequence: categories: ["A", "B"]
+        if val.startswith("["):
+            inner = val.strip("[]")
+            items = [v.strip().strip('"').strip("'") for v in inner.split(",") if v.strip()]
+            result[key] = items
+        elif val == "":
+            # Start of a block sequence
+            list_key = key
+            list_items = []
+        else:
+            result[key] = val.strip('"').strip("'")
+    if list_key and list_items:
+        result[list_key] = list_items
+    return result
+
+
+# ── Filename sanitisation ─────────────────────────────────────────────────────
+
+def safe_dirname(name: str) -> str:
+    """Turn a category name into a safe directory name."""
+    name = name.strip()
+    name = re.sub(r'[<>:"/\\|?*\n\r]', '', name)
+    name = re.sub(r'\s+', ' ', name)
+    return name or "General"
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Organise Siftly Obsidian export by category.",
+    )
+    parser.add_argument("directory", help="Path to the export directory (contains .md files)")
+    parser.add_argument("--copy", action="store_true", help="Copy files instead of moving them")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would happen, don't touch files")
+    parser.add_argument("--no-symlinks", action="store_true", help="Copy into every category folder instead of symlinking")
+    args = parser.parse_args()
+
+    export_dir = Path(args.directory).resolve()
+    if not export_dir.is_dir():
+        sys.exit(f"Error: '{export_dir}' is not a directory.")
+
+    # Collect .md files (non-recursive so we don't re-process already organised files)
+    md_files = sorted(export_dir.glob("*.md"))
+    if not md_files:
+        sys.exit(f"No .md files found directly inside '{export_dir}'.")
+
+    print(f"Found {len(md_files)} notes in {export_dir}\n")
+
+    # Map: category_name → [file_path, ...]
+    by_category: dict[str, list[Path]] = defaultdict(list)
+    uncategorized: list[Path] = []
+
+    for md_path in md_files:
+        text = md_path.read_text(encoding="utf-8", errors="replace")
+        fm = parse_frontmatter(text)
+        categories: list[str] = []
+        raw = fm.get("categories", [])
+        if isinstance(raw, list):
+            categories = [c for c in raw if c]
+        elif isinstance(raw, str) and raw:
+            categories = [raw]
+
+        if categories:
+            for cat in categories:
+                by_category[cat].append(md_path)
+        else:
+            uncategorized.append(md_path)
+
+    if uncategorized:
+        by_category["General"] += uncategorized
+
+    # Summary
+    print("Categories detected:")
+    for cat, files in sorted(by_category.items()):
+        print(f"  {cat!r:40s} → {len(files)} notes")
+    print()
+
+    if args.dry_run:
+        print("[dry-run] No files were modified.")
+        return
+
+    moved: int = 0
+    copied: int = 0
+    linked: int = 0
+    errors: int = 0
+
+    # Process each category
+    for cat, files in by_category.items():
+        cat_dir = export_dir / safe_dirname(cat)
+        cat_dir.mkdir(exist_ok=True)
+
+        # The first occurrence → move (or copy) the real file
+        # Additional occurrences (multi-category) → symlink or copy
+        for i, src in enumerate(files):
+            dest = cat_dir / src.name
+            if dest.exists():
+                # Skip — already placed (e.g. previous run)
+                continue
+
+            is_primary = i == 0 or args.copy or args.no_symlinks
+
+            if is_primary:
+                if args.copy:
+                    shutil.copy2(src, dest)
+                    copied += 1
+                    print(f"  copy  {src.name} → {cat}/")
+                else:
+                    # Move on first category, symlink for subsequent
+                    if src.exists():
+                        shutil.move(str(src), dest)
+                        moved += 1
+                        print(f"  move  {src.name} → {cat}/")
+                    else:
+                        # File already moved to another category — symlink back
+                        _create_symlink(dest, src, cat)
+                        linked += 1
+            else:
+                # Multi-category: create symlink pointing to whichever dir now owns the real file
+                real_location = _find_real_location(export_dir, src.name, by_category)
+                if real_location and not args.no_symlinks:
+                    try:
+                        dest.symlink_to(os.path.relpath(real_location, cat_dir))
+                        linked += 1
+                        print(f"  link  {src.name} → {cat}/ (→ {real_location.parent.name}/)")
+                    except OSError as e:
+                        print(f"  [warn] Could not create symlink for {src.name}: {e}")
+                        errors += 1
+                else:
+                    # Fall back to copy
+                    if real_location and real_location.exists():
+                        shutil.copy2(real_location, dest)
+                        copied += 1
+                        print(f"  copy  {src.name} → {cat}/ (multi-category)")
+
+    print(f"\nDone. Moved: {moved}  Copied: {copied}  Symlinked: {linked}  Errors: {errors}")
+
+
+def _find_real_location(export_dir: Path, filename: str, by_category: dict) -> Path | None:
+    """Find where a file ended up after being moved (first category that has it as a real file)."""
+    for cat, files in by_category.items():
+        for f in files:
+            candidate = export_dir / safe_dirname(cat) / filename
+            if candidate.exists() and not candidate.is_symlink():
+                return candidate
+    return None
+
+
+def _create_symlink(dest: Path, src: Path, cat: str) -> None:
+    try:
+        dest.symlink_to(src.resolve())
+    except OSError as e:
+        print(f"  [warn] Could not symlink {src.name} in {cat}/: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two new features for importing and organizing bookmarks.

### 1. Import from URLs (UI + API)

**New tab `From URLs` in the Import page**

Paste a list of tweet URLs (one per line or comma-separated) and Siftly will:
1. Fetch tweet content via Twitter oEmbed API (no auth required)
2. Import into the DB, skipping duplicates
3. Run the full AI pipeline: vision analysis → entity extraction → semantic tags → categorization
4. Optionally export notes directly to Obsidian, organized by category

**New API endpoint: `POST /api/import/url`**

```json
{
  "urls": ["https://x.com/user/status/123..."],
  "exportToObsidian": true,
  "vaultPath": "/Users/you/MyVault"
}
```

Returns: `{ imported, skipped, fetchFailed, invalidUrls, categorized, exported }`

### 2. Per-category Obsidian export

**New `exportBookmarksByCategoryToObsidian()`** in `lib/obsidian-exporter.ts`

Writes notes to `{vault}/Twitter Bookmarks/{Category Name}/note.md` instead of a flat folder. Used by the URL import flow.

### 3. Python organizer script

**`scripts/organize-by-category.py`** — standalone script for existing flat exports

```bash
# Move notes into category subfolders (default)
python scripts/organize-by-category.py /path/to/export

# Preview without touching files
python scripts/organize-by-category.py /path/to/export --dry-run

# Copy instead of move (multi-category bookmarks get copied to each)
python scripts/organize-by-category.py /path/to/export --copy
```

No external dependencies — pure Python 3 stdlib. Reads `categories:` from note frontmatter, creates subfolders, and uses symlinks for bookmarks assigned to multiple categories.

## Files changed

- `app/api/import/url/route.ts` — new API endpoint
- `app/import/page.tsx` — new `From URLs` tab with Obsidian export toggle
- `lib/obsidian-exporter.ts` — `exportBookmarksByCategoryToObsidian()`
- `scripts/organize-by-category.py` — standalone organizer script