### PR TITLE
feat(import): incremental X capture from last file-import job

### DIFF
--- a/app/api/import/last-job-first-timeline-tweets/route.ts
+++ b/app/api/import/last-job-first-timeline-tweets/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/db'
+
+/** Latest completed file import per capture type (matches live import filenames on /import). */
+function jobWhereForPrefix(prefix: 'bookmarks-' | 'likes-') {
+  return {
+    status: 'done' as const,
+    filename: { startsWith: prefix, endsWith: '.json' },
+  }
+}
+
+async function firstTweetInJobWindow(
+  job: { createdAt: Date; updatedAt: Date },
+  source: 'bookmark' | 'like'
+): Promise<string | null> {
+  const row = await prisma.bookmark.findFirst({
+    where: {
+      source,
+      importedAt: { gte: job.createdAt, lte: job.updatedAt },
+    },
+    orderBy: { importedAt: 'asc' },
+    select: { tweetId: true },
+  })
+  return row?.tweetId ?? null
+}
+
+/**
+ * For each of the latest `done` jobs named `bookmarks-*.json` / `likes-*.json`,
+ * finds bookmarks whose `importedAt` falls in that job's `[createdAt, updatedAt]`,
+ * ordered by `importedAt` ascending — returns the first row's `tweetId` per job.
+ */
+export async function GET(): Promise<NextResponse> {
+  const [bookmarkJob, likeJob] = await Promise.all([
+    prisma.importJob.findFirst({
+      where: jobWhereForPrefix('bookmarks-'),
+      orderBy: { updatedAt: 'desc' },
+    }),
+    prisma.importJob.findFirst({
+      where: jobWhereForPrefix('likes-'),
+      orderBy: { updatedAt: 'desc' },
+    }),
+  ])
+
+  const [bookmarkTweetId, likeTweetId] = await Promise.all([
+    bookmarkJob ? firstTweetInJobWindow(bookmarkJob, 'bookmark') : Promise.resolve(null),
+    likeJob ? firstTweetInJobWindow(likeJob, 'like') : Promise.resolve(null),
+  ])
+
+  return NextResponse.json({ bookmarkTweetId, likeTweetId })
+}

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -69,6 +69,20 @@ const IMPORT_CAPTURE_SCRIPTS = {
   console: '/js/import-console.js',
 } as const
 
+function compactBookmarkletScript(script: string) {
+  return script
+    .replace(/^\uFEFF/, '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => {
+      if (!line) return false
+      if (line.startsWith('//')) return false
+      if (line.startsWith('/*') && line.endsWith('*/')) return false
+      return true
+    })
+    .join(' ')
+}
+
 // ── Draggable bookmarklet link ────────────────────────────────────────────────
 // React blocks javascript: URLs set via JSX href as a security precaution.
 // We bypass this by setting the href attribute imperatively after mount so the
@@ -665,7 +679,9 @@ function InstructionsStep({ onFile, importSource, onLiveSynced }: { onFile: (fil
     }
   }, [])
 
-  const bookmarkletHref = captureBookmarklet ? `javascript:${encodeURIComponent(captureBookmarklet)}` : ''
+  const bookmarkletHref = captureBookmarklet
+    ? `javascript:${encodeURIComponent(compactBookmarkletScript(captureBookmarklet))}`
+    : ''
 
   return (
     <div>

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -255,17 +255,21 @@ function BookmarkletTab({
       num: 2,
       title: (
         <span>
-          Go to{' '}
-          <a
-            href={targetUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-indigo-400 hover:underline inline-flex items-center gap-1"
+          Click this{' '}
+          <button
+            type="button"
+            onClick={() => window.open(targetUrl, 'siftly_x_capture')}
+            className="text-indigo-400 hover:text-indigo-300 hover:underline inline-flex items-center gap-1 align-baseline bg-transparent border-0 p-0 cursor-pointer font-inherit"
           >
             {targetLabel} <ExternalLink size={11} />
-          </a>{' '}
-          while logged in
+          </button>{' '}
+          in a <kbd className="text-xs bg-zinc-800 border border-zinc-700 px-1.5 py-0.5 rounded font-mono">linked-window</kbd> while logged in
         </span>
+      ),
+      content: (
+        <p className="text-xs text-zinc-500 mt-1">
+          Keep this Import tab open to receive captured bookmarks and import them automatically.
+        </p>
       ),
     },
     {
@@ -283,16 +287,17 @@ function BookmarkletTab({
       content: (
         <p className="text-xs text-zinc-500 mt-1">
           A second button appears below the export button. Click it and it will scroll through all your bookmarks automatically — stopping when done. Or scroll manually if you prefer.
+          When scrolling finishes, bookmarks are sent to this tab automatically (no file upload). You can still use Export to download JSON.
         </p>
       ),
     },
     {
       num: 5,
-      title: `Click the purple "Export N ${sourceLabel}" button`,
+      title: `Optional: Click the purple "Export N ${sourceLabel}" button`,
       content: (
         <p className="text-xs text-zinc-500 mt-1">
           A <code className="text-xs bg-zinc-800 px-1 py-0.5 rounded">{sourceLabel}.json</code> file will download automatically.
-          Upload it below.
+          Upload it below. <kbd className="text-xs bg-zinc-800 border border-zinc-700 px-1.5 py-0.5 rounded font-mono">linked-window</kbd> will import automatically and skip this step. 
         </p>
       ),
     },
@@ -343,17 +348,21 @@ function ConsoleTab({
       num: 1,
       title: (
         <span>
-          Go to{' '}
-          <a
-            href={targetUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-indigo-400 hover:underline inline-flex items-center gap-1"
+          Click this{' '}
+          <button
+            type="button"
+            onClick={() => window.open(targetUrl, 'siftly_x_capture')}
+            className="text-indigo-400 hover:text-indigo-300 hover:underline inline-flex items-center gap-1 align-baseline bg-transparent border-0 p-0 cursor-pointer font-inherit"
           >
             {targetLabel} <ExternalLink size={11} />
-          </a>{' '}
-          while logged in
+          </button>{' '}
+          in a <kbd className="text-xs bg-zinc-800 border border-zinc-700 px-1.5 py-0.5 rounded font-mono">linked-window</kbd> while logged in
         </span>
+      ),
+      content: (
+        <p className="text-xs text-zinc-500 mt-1">
+           Keep this Import tab open to receive captured bookmarks and import them automatically.
+        </p>
       ),
     },
     {
@@ -400,6 +409,7 @@ function ConsoleTab({
       content: (
         <p className="text-xs text-zinc-500 mt-1">
           A purple button will appear. Scroll slowly to capture all {sourceLabel}, then click the button to download.
+          <kbd className="text-xs bg-zinc-800 border border-zinc-700 px-1.5 py-0.5 rounded font-mono">linked-window</kbd> will import automatically no need to upload.
         </p>
       ),
     },
@@ -1124,7 +1134,8 @@ export default function ImportPage() {
     setTimeout(() => setStep(3), 1500)
   }
 
-  async function handleFile(file: File) {
+  const handleFile = useCallback(async (file: File, sourceOverride?: 'bookmark' | 'like') => {
+    const source = sourceOverride ?? importSource
     setStep(2)
     setImporting(true)
     setImportError('')
@@ -1132,7 +1143,7 @@ export default function ImportPage() {
     try {
       const formData = new FormData()
       formData.append('file', file)
-      formData.append('source', importSource)
+      formData.append('source', source)
 
       const res = await fetch('/api/import', { method: 'POST', body: formData })
       const data = await res.json()
@@ -1164,7 +1175,24 @@ export default function ImportPage() {
     } finally {
       setImporting(false)
     }
-  }
+  }, [importSource])
+
+  useEffect(() => {
+    const xOrigins = new Set(['https://x.com', 'https://twitter.com'])
+    function onMessage(e: MessageEvent) {
+      if (!xOrigins.has(e.origin)) return
+      if (e.data?.type !== 'SIFTLY_BOOKMARK_CAPTURE' || !Array.isArray(e.data.bookmarks)) return
+      const src = e.data.source === 'like' ? 'like' : 'bookmark'
+      const json = JSON.stringify({ bookmarks: e.data.bookmarks, source: src }, null, 2)
+      const d = new Date()
+      const ts = `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}-${String(d.getHours()).padStart(2, '0')}${String(d.getMinutes()).padStart(2, '0')}${String(d.getSeconds()).padStart(2, '0')}`
+      const name = `${src === 'like' ? 'likes' : 'bookmarks'}-${ts}.json`
+      const file = new File([json], name, { type: 'application/json' })
+      void handleFile(file, src)
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [handleFile])
 
   return (
     <div className="p-8 max-w-2xl mx-auto">

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -62,313 +62,34 @@ const STAGE_INFO: Record<NonNullable<Stage>, { label: string; icon: React.ReactN
   },
 }
 
-// ── Bookmarklet script (captures Twitter/X bookmark API responses as you scroll) ──
+// Bookmarklet / console capture scripts live in public/js; InstructionsStep fetches them on mount.
 
-const BOOKMARKLET_SCRIPT = `(async function(){
-  if(!location.hostname.includes('twitter.com')&&!location.hostname.includes('x.com')){
-    showToast('\u274c Please navigate to x.com/i/bookmarks or x.com/username/likes first','#ef4444');return;
-  }
-  var isLikes=location.pathname.includes('/likes');
-  var source=isLikes?'like':'bookmark';
-  var label=isLikes?'likes':'bookmarks';
-  function showToast(msg,bg){
-    var t=document.createElement('div');t.textContent=msg;
-    Object.assign(t.style,{position:'fixed',bottom:'24px',left:'50%',transform:'translateX(-50%)',
-      zIndex:'2147483647',padding:'10px 18px',background:bg||'#1e1b4b',color:'#fff',
-      border:'1px solid rgba(255,255,255,0.15)',borderRadius:'8px',
-      fontSize:'13px',fontWeight:'600',fontFamily:'system-ui,sans-serif',
-      boxShadow:'0 4px 20px rgba(0,0,0,0.6)',whiteSpace:'nowrap',transition:'opacity 0.3s'});
-    document.body.appendChild(t);
-    setTimeout(function(){t.style.opacity='0';setTimeout(function(){t.remove();},300);},4000);
-  }
-  var all=[],seen=new Set();
-  var btn=document.createElement('button');
-  btn.textContent='Scroll, then Export 0 '+label+' \u2192';
-  Object.assign(btn.style,{position:'fixed',top:'12px',right:'12px',zIndex:'2147483647',
-    padding:'10px 18px',background:'#4f46e5',color:'#fff',border:'none',borderRadius:'8px',
-    cursor:'pointer',fontSize:'14px',fontWeight:'700',
-    boxShadow:'0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
-    fontFamily:'system-ui,sans-serif'});
-  function addTweet(t){
-    if(!t||!t.rest_id||seen.has(t.rest_id))return;
-    seen.add(t.rest_id);
-    var leg=t.legacy||{},usr=(t.core&&t.core.user_results&&t.core.user_results.result&&t.core.user_results.result.legacy)||{};
-    var rawMedia=(leg.extended_entities&&leg.extended_entities.media)||(leg.entities&&leg.entities.media)||[];
-    var media=rawMedia.map(function(m){
-      var thumb=m.media_url_https||'';
-      if(m.type==='video'||m.type==='animated_gif'){
-        var variants=m.video_info&&m.video_info.variants||[];
-        var mp4s=variants.filter(function(v){return v.content_type==='video/mp4'&&v.url;}).sort(function(a,b){return(b.bitrate||0)-(a.bitrate||0);});
-        if(mp4s.length)return{type:m.type==='animated_gif'?'gif':'video',url:mp4s[0].url};
-        // No mp4 — degrade to photo so thumbnail shows correctly (actual video not available)
-        if(thumb)return{type:'photo',url:thumb};
-        return null;
-      }
-      return thumb?{type:'photo',url:thumb}:null;
-    }).filter(Boolean);
-    all.push({id:t.rest_id,author:usr.name||'Unknown',handle:'@'+(usr.screen_name||'unknown'),
-      avatar:usr.profile_image_url_https||'',timestamp:leg.created_at||'',
-      text:leg.full_text||leg.text||'',media:media,
-      hashtags:(leg.entities&&leg.entities.hashtags||[]).map(function(h){return h.text;}),
-      urls:(leg.entities&&leg.entities.urls||[]).map(function(u){return u.expanded_url;}).filter(Boolean)});
-    btn.textContent='Export '+all.length+' '+label+' \u2192';
-  }
-  function isTweetObj(o){return o&&typeof o==='object'&&typeof o.rest_id==='string'&&o.rest_id.length>5&&(o.legacy||o.core);}
-  function unwrapTweet(t){
-    if(!t)return null;
-    if(t.__typename==='TweetWithVisibilityResults'||t.__typename==='TweetWithVisibilityResult')return t.tweet||t;
-    return t;
-  }
-  function deepFindTweets(obj,depth){
-    if(!obj||typeof obj!=='object'||depth>12)return;
-    if(Array.isArray(obj)){obj.forEach(function(item){deepFindTweets(item,depth+1);});return;}
-    if(obj.tweet_results&&obj.tweet_results.result){var tw=unwrapTweet(obj.tweet_results.result);if(tw)addTweet(tw);}
-    else if(isTweetObj(obj)){addTweet(unwrapTweet(obj));}
-    for(var k in obj){if(Object.prototype.hasOwnProperty.call(obj,k)&&k!=='quoted_status_result'){deepFindTweets(obj[k],depth+1);}}
-  }
-  function processData(d){deepFindTweets(d,0);}
-  var autoBtn=document.createElement('button');
-  function doExport(){
-    window.fetch=origFetch;
-    XMLHttpRequest.prototype.open=origOpen;
-    XMLHttpRequest.prototype.send=origSend;
-    if(!all.length){showToast('\u26a0\ufe0f No '+label+' captured \u2014 scroll or use Auto-scroll first!','#92400e');return;}
-    [btn,autoBtn].forEach(function(el){try{document.body.removeChild(el);}catch(e){}});
-    var blob=new Blob([JSON.stringify({bookmarks:all,source:source},null,2)],{type:'application/json'});
-    var url=URL.createObjectURL(blob);
-    var a=document.createElement('a');a.href=url;a.download=source+'s.json';a.click();
-    setTimeout(function(){URL.revokeObjectURL(url);},1000);
-    showToast('\u2705 Downloaded '+all.length+' '+label+'! Upload to Siftly.','#14532d');
-  }
-  btn.onclick=doExport;
-  autoBtn.textContent='\u25b6 Auto-scroll';
-  Object.assign(autoBtn.style,{position:'fixed',top:'58px',right:'12px',zIndex:'2147483647',
-    padding:'8px 14px',background:'#18181b',color:'#a1a1aa',
-    border:'1px solid #3f3f46',borderRadius:'8px',
-    cursor:'pointer',fontSize:'12px',fontWeight:'600',fontFamily:'system-ui,sans-serif'});
-  var autoScrolling=false;
-  function sleep(ms){return new Promise(function(r){setTimeout(r,ms);});}
-  async function runAutoScroll(){
-    var stagnant=0,lastCount=all.length;
-    while(autoScrolling){
-      window.scrollTo(0,document.documentElement.scrollHeight);
-      var col=document.querySelector('[data-testid="primaryColumn"]');
-      if(col)col.scrollTo(0,col.scrollHeight);
-      await sleep(900);
-      if(all.length>lastCount){stagnant=0;lastCount=all.length;}
-      else{
-        stagnant++;
-        if(stagnant>=8){
-          window.scrollTo(0,document.documentElement.scrollHeight);
-          await sleep(2000);
-          if(all.length===lastCount){
-            autoScrolling=false;
-            autoBtn.textContent='\u2705 Done \u2014 '+all.length+' captured';
-            autoBtn.style.background='#14532d';autoBtn.style.color='#86efac';autoBtn.style.border='1px solid #166534';
-            showToast('\u2705 Auto-scroll complete! '+all.length+' '+label+' ready. Click Export.','#14532d');
-            return;
-          }
-          stagnant=0;
-        }
-      }
-    }
-    autoBtn.textContent='\u25b6 Auto-scroll';
-    autoBtn.style.background='#18181b';autoBtn.style.color='#a1a1aa';autoBtn.style.border='1px solid #3f3f46';
-  }
-  autoBtn.onclick=function(){
-    if(autoScrolling){autoScrolling=false;return;}
-    autoScrolling=true;
-    autoBtn.textContent='\u23f8 Stop';
-    autoBtn.style.background='#4f46e5';autoBtn.style.color='#fff';autoBtn.style.border='none';
-    runAutoScroll();
-  };
-  document.body.appendChild(btn);
-  document.body.appendChild(autoBtn);
-  function isApiUrl(u){return u.includes('/graphql/')||u.includes('/i/api/')||u.includes('/2/timeline');}
-  var origFetch=window.fetch;
-  window.fetch=async function(){
-    var r=await origFetch.apply(this,arguments);
-    try{
-      var u=arguments[0] instanceof Request?arguments[0].url:String(arguments[0]);
-      if(isApiUrl(u)){var ct=r.headers.get('content-type')||'';if(ct.includes('json')){var d=await r.clone().json();processData(d);}}
-    }catch(ex){}
-    return r;
-  };
-  var origOpen=XMLHttpRequest.prototype.open,origSend=XMLHttpRequest.prototype.send,xhrUrls=new WeakMap();
-  XMLHttpRequest.prototype.open=function(){xhrUrls.set(this,String(arguments[1]||''));return origOpen.apply(this,arguments);};
-  XMLHttpRequest.prototype.send=function(){
-    var xhr=this,u=xhrUrls.get(xhr)||'';
-    if(isApiUrl(u)){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
-    return origSend.apply(this,arguments);
-  };
-  showToast('\u2705 Active! Scroll your '+label+' \u2014 counter updates above.','#1e1b4b');
-})();`
-
-const BOOKMARKLET_HREF = `javascript:${encodeURIComponent(BOOKMARKLET_SCRIPT)}`
-
-const CONSOLE_SCRIPT = `(async function() {
-  if (!location.hostname.includes('twitter.com') && !location.hostname.includes('x.com')) {
-    alert('Run this on x.com/i/bookmarks or x.com/username/likes'); return;
-  }
-  const isLikes = location.pathname.includes('/likes');
-  const source = isLikes ? 'like' : 'bookmark';
-  const label = isLikes ? 'likes' : 'bookmarks';
-  const all = [], seen = new Set();
-  function addTweet(t) {
-    if (!t?.rest_id || seen.has(t.rest_id)) return;
-    seen.add(t.rest_id);
-    const leg = t.legacy ?? {}, usr = t.core?.user_results?.result?.legacy ?? {};
-    const media = (leg.extended_entities?.media ?? leg.entities?.media ?? []).map(m => {
-      const thumb = m.media_url_https ?? '';
-      if (m.type === 'video' || m.type === 'animated_gif') {
-        const mp4s = (m.video_info?.variants ?? []).filter(v => v.content_type === 'video/mp4' && v.url)
-          .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
-        if (mp4s.length) return { type: m.type === 'animated_gif' ? 'gif' : 'video', url: mp4s[0].url };
-        // No mp4 — degrade to photo so thumbnail shows correctly (actual video not available)
-        return thumb ? { type: 'photo', url: thumb } : null;
-      }
-      return thumb ? { type: 'photo', url: thumb } : null;
-    }).filter(Boolean);
-    all.push({
-      id: t.rest_id, author: usr.name ?? 'Unknown', handle: '@' + (usr.screen_name ?? 'unknown'),
-      timestamp: leg.created_at ?? '', text: leg.full_text ?? leg.text ?? '', media,
-      hashtags: (leg.entities?.hashtags ?? []).map(h => h.text),
-      urls: (leg.entities?.urls ?? []).map(u => u.expanded_url).filter(Boolean)
-    });
-    btn.textContent = \`Export \${all.length} \${label} →\`;
-  }
-  function isTweetObj(o) { return o && typeof o === 'object' && typeof o.rest_id === 'string' && o.rest_id.length > 5 && (o.legacy || o.core); }
-  function unwrapTweet(t) {
-    if (!t) return null;
-    if (t.__typename === 'TweetWithVisibilityResults' || t.__typename === 'TweetWithVisibilityResult') return t.tweet ?? t;
-    return t;
-  }
-  function deepFindTweets(obj, depth = 0) {
-    if (!obj || typeof obj !== 'object' || depth > 12) return;
-    if (Array.isArray(obj)) { obj.forEach(item => deepFindTweets(item, depth + 1)); return; }
-    if (obj.tweet_results?.result) { const tw = unwrapTweet(obj.tweet_results.result); if (tw) addTweet(tw); }
-    else if (isTweetObj(obj)) { addTweet(unwrapTweet(obj)); }
-    for (const k of Object.keys(obj)) { if (k !== 'quoted_status_result') deepFindTweets(obj[k], depth + 1); }
-  }
-  function processData(d) { deepFindTweets(d, 0); }
-  const btn = document.createElement('button');
-  btn.textContent = 'Scroll then click to Export →';
-  Object.assign(btn.style, {
-    position: 'fixed', top: '12px', right: '12px', zIndex: '2147483647',
-    padding: '10px 18px', background: '#4f46e5', color: '#fff',
-    border: 'none', borderRadius: '8px', cursor: 'pointer',
-    fontSize: '14px', fontWeight: '700',
-    boxShadow: '0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
-    fontFamily: 'system-ui,sans-serif'
-  });
-  function doExport() {
-    window.fetch = origFetch;
-    XMLHttpRequest.prototype.open = origOpen;
-    XMLHttpRequest.prototype.send = origSend;
-    [btn, autoBtn].forEach(el => { try { document.body.removeChild(el); } catch(e) {} });
-    if (!all.length) { alert(\`No \${label} captured. Use Auto-scroll or scroll manually first.\`); return; }
-    const blob = new Blob([JSON.stringify({ bookmarks: all, source }, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url; a.download = \`\${source}s.json\`; a.click();
-    setTimeout(() => URL.revokeObjectURL(url), 1000);
-    console.log(\`✅ Downloaded \${all.length} \${label}!\`);
-  }
-  btn.onclick = doExport;
-  const autoBtn = document.createElement('button');
-  autoBtn.textContent = '▶ Auto-scroll';
-  Object.assign(autoBtn.style, {
-    position: 'fixed', top: '58px', right: '12px', zIndex: '2147483647',
-    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
-    border: '1px solid #3f3f46', borderRadius: '8px', cursor: 'pointer',
-    fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
-  });
-  let autoScrolling = false;
-  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-  async function runAutoScroll() {
-    let stagnant = 0, lastCount = all.length;
-    while (autoScrolling) {
-      window.scrollTo(0, document.documentElement.scrollHeight);
-      const col = document.querySelector('[data-testid="primaryColumn"]');
-      col?.scrollTo(0, col.scrollHeight);
-      await sleep(900);
-      if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
-      else {
-        stagnant++;
-        if (stagnant >= 8) {
-          window.scrollTo(0, document.documentElement.scrollHeight);
-          await sleep(2000);
-          if (all.length === lastCount) {
-            autoScrolling = false;
-            autoBtn.textContent = \`✅ Done — \${all.length} captured\`;
-            autoBtn.style.cssText += ';background:#14532d;color:#86efac;border:1px solid #166534';
-            console.log(\`✅ Auto-scroll complete! \${all.length} \${label} ready. Click Export.\`);
-            return;
-          }
-          stagnant = 0;
-        }
-      }
-    }
-    autoBtn.textContent = '▶ Auto-scroll';
-    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
-  }
-  autoBtn.onclick = function() {
-    if (autoScrolling) { autoScrolling = false; return; }
-    autoScrolling = true;
-    autoBtn.textContent = '⏸ Stop';
-    autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
-    runAutoScroll();
-  };
-  document.body.appendChild(btn);
-  document.body.appendChild(autoBtn);
-  const isApiUrl = (u) => u.includes('/graphql/') || u.includes('/i/api/') || u.includes('/2/timeline');
-  const origFetch = window.fetch;
-  window.fetch = async function(...args) {
-    const r = await origFetch.apply(this, args);
-    try {
-      const u = args[0] instanceof Request ? args[0].url : String(args[0]);
-      if (isApiUrl(u)) { const ct = r.headers.get('content-type') ?? ''; if (ct.includes('json')) { const d = await r.clone().json(); processData(d); } }
-    } catch(e) {}
-    return r;
-  };
-  const origOpen = XMLHttpRequest.prototype.open;
-  const origSend = XMLHttpRequest.prototype.send;
-  const xhrUrls = new WeakMap();
-  XMLHttpRequest.prototype.open = function(...args) {
-    xhrUrls.set(this, String(args[1] ?? ''));
-    return origOpen.apply(this, args);
-  };
-  XMLHttpRequest.prototype.send = function(...args) {
-    const xhr = this, u = xhrUrls.get(xhr) ?? '';
-    if (isApiUrl(u)) {
-      xhr.addEventListener('load', function() {
-        try { processData(JSON.parse(xhr.responseText)); } catch(e) {}
-      });
-    }
-    return origSend.apply(this, args);
-  };
-  console.log(\`✅ Script active. Scroll through your \${label}, then click the purple button.\`);
-})();`
+const IMPORT_CAPTURE_SCRIPTS = {
+  bookmarklet: '/js/import-bookmarklet.js',
+  console: '/js/import-console.js',
+} as const
 
 // ── Draggable bookmarklet link ────────────────────────────────────────────────
 // React blocks javascript: URLs set via JSX href as a security precaution.
 // We bypass this by setting the href attribute imperatively after mount so the
 // drag-to-bookmark-bar flow still works correctly in all browsers.
 
-function DraggableBookmarklet() {
+function DraggableBookmarklet({ bookmarkletHref }: { bookmarkletHref: string }) {
   const linkRef = useRef<HTMLAnchorElement>(null)
 
   useEffect(() => {
     // Set href imperatively — bypasses React's javascript: URL XSS guard
-    linkRef.current?.setAttribute('href', BOOKMARKLET_HREF)
-  }, [])
+    if (bookmarkletHref) linkRef.current?.setAttribute('href', bookmarkletHref)
+  }, [bookmarkletHref])
 
   return (
     <a
       ref={linkRef}
-      draggable
+      draggable={!!bookmarkletHref}
       onClick={(e) => e.preventDefault()}
-      className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-xs font-semibold cursor-grab active:cursor-grabbing select-none transition-colors"
+      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-indigo-600 text-white text-xs font-semibold select-none transition-colors ${
+        bookmarkletHref ? 'hover:bg-indigo-500 cursor-grab active:cursor-grabbing' : 'opacity-40 cursor-not-allowed pointer-events-none'
+      }`}
       title="Drag this to your bookmarks bar — do not click"
     >
       📥 Export X Bookmarks
@@ -402,9 +123,10 @@ function StepIndicator({ current }: { current: Step }) {
   )
 }
 
-function CopyButton({ text }: { text: string }) {
+function CopyButton({ text, disabled }: { text: string; disabled?: boolean }) {
   const [copied, setCopied] = useState(false)
   function handleCopy() {
+    if (!text || disabled) return
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
@@ -412,8 +134,10 @@ function CopyButton({ text }: { text: string }) {
   }
   return (
     <button
+      type="button"
       onClick={handleCopy}
-      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-colors"
+      disabled={disabled || !text}
+      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-colors disabled:opacity-40 disabled:pointer-events-none"
     >
       {copied ? <Check size={12} className="text-emerald-400" /> : <Copy size={12} />}
       {copied ? 'Copied!' : 'Copy'}
@@ -455,7 +179,19 @@ function UploadZone({ onFile }: { onFile: (file: File) => void }) {
   )
 }
 
-function BookmarkletTab({ onFile, importSource }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like' }) {
+function BookmarkletTab({
+  onFile,
+  importSource,
+  bookmarkletHref,
+  captureScriptsLoading,
+  captureScriptsError,
+}: {
+  onFile: (file: File) => void
+  importSource: 'bookmark' | 'like'
+  bookmarkletHref: string
+  captureScriptsLoading: boolean
+  captureScriptsError: string | null
+}) {
   const targetUrl = importSource === 'like' ? 'https://x.com' : 'https://x.com/i/bookmarks'
   const targetLabel = importSource === 'like' ? 'x.com/YourUsername/likes' : 'x.com/i/bookmarks'
   const sourceLabel = importSource === 'like' ? 'likes' : 'bookmarks'
@@ -465,6 +201,15 @@ function BookmarkletTab({ onFile, importSource }: { onFile: (file: File) => void
       title: 'Add the bookmarklet to your bookmark bar',
       content: (
         <div className="mt-2 space-y-3">
+          {captureScriptsError && (
+            <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2">{captureScriptsError}</p>
+          )}
+          {captureScriptsLoading && !captureScriptsError && (
+            <p className="text-xs text-zinc-500 flex items-center gap-2">
+              <Loader2 size={14} className="animate-spin shrink-0" />
+              Loading bookmarklet…
+            </p>
+          )}
           <p className="text-xs text-zinc-500">
             Show your bookmark bar first: <strong className="text-zinc-300">View → Show Bookmarks Bar</strong>
           </p>
@@ -473,7 +218,7 @@ function BookmarkletTab({ onFile, importSource }: { onFile: (file: File) => void
             <div className="shrink-0 w-6 h-6 rounded-full bg-indigo-500/20 text-indigo-400 flex items-center justify-center text-xs font-bold">A</div>
             <div className="min-w-0">
               <p className="text-xs font-medium text-zinc-300 mb-1.5">Drag to bookmark bar</p>
-              <DraggableBookmarklet />
+              <DraggableBookmarklet bookmarkletHref={bookmarkletHref} />
             </div>
           </div>
           {/* Option B: Manual (more reliable in Chrome) */}
@@ -486,7 +231,7 @@ function BookmarkletTab({ onFile, importSource }: { onFile: (file: File) => void
                 <li>2. Right-click bookmark bar → <strong className="text-zinc-400">Add bookmark / New bookmark</strong></li>
                 <li>3. Name it <em className="text-zinc-400">Export X Bookmarks</em> and paste the URL</li>
               </ol>
-              <CopyButton text={BOOKMARKLET_HREF} />
+              <CopyButton text={bookmarkletHref} disabled={captureScriptsLoading || !!captureScriptsError} />
             </div>
           </div>
         </div>
@@ -563,7 +308,19 @@ function BookmarkletTab({ onFile, importSource }: { onFile: (file: File) => void
   )
 }
 
-function ConsoleTab({ onFile, importSource }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like' }) {
+function ConsoleTab({
+  onFile,
+  importSource,
+  consoleScript,
+  captureScriptsLoading,
+  captureScriptsError,
+}: {
+  onFile: (file: File) => void
+  importSource: 'bookmark' | 'like'
+  consoleScript: string
+  captureScriptsLoading: boolean
+  captureScriptsError: string | null
+}) {
   const targetUrl = importSource === 'like' ? 'https://x.com' : 'https://x.com/i/bookmarks'
   const targetLabel = importSource === 'like' ? 'x.com/YourUsername/likes' : 'x.com/i/bookmarks'
   const sourceLabel = importSource === 'like' ? 'likes' : 'bookmarks'
@@ -601,13 +358,23 @@ function ConsoleTab({ onFile, importSource }: { onFile: (file: File) => void; im
       title: 'Paste and run the script below',
       content: (
         <div className="mt-2">
+          {captureScriptsError && (
+            <p className="text-xs text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 mb-2">{captureScriptsError}</p>
+          )}
           <div className="relative rounded-xl overflow-hidden border border-zinc-700 bg-zinc-950">
             <div className="flex items-center justify-between px-3 py-2 border-b border-zinc-800">
               <span className="text-xs text-zinc-600 font-mono">console script</span>
-              <CopyButton text={CONSOLE_SCRIPT} />
+              <CopyButton text={consoleScript} disabled={captureScriptsLoading || !!captureScriptsError} />
             </div>
             <pre className="text-xs text-zinc-400 p-3 overflow-auto max-h-40 font-mono leading-relaxed">
-              {CONSOLE_SCRIPT.slice(0, 300)}...
+              {captureScriptsLoading && !captureScriptsError ? (
+                <span className="text-zinc-500 flex items-center gap-2">
+                  <Loader2 size={14} className="animate-spin shrink-0" />
+                  Loading script…
+                </span>
+              ) : (
+                <>{consoleScript.slice(0, 300)}...</>
+              )}
             </pre>
           </div>
         </div>
@@ -863,6 +630,42 @@ function LiveImportTab({ onSynced }: { onSynced: (result: ImportResult) => void 
 
 function InstructionsStep({ onFile, importSource, onLiveSynced }: { onFile: (file: File) => void; importSource: 'bookmark' | 'like'; onLiveSynced: (result: ImportResult) => void }) {
   const [method, setMethod] = useState<Method>('bookmarklet')
+  const [captureBookmarklet, setCaptureBookmarklet] = useState('')
+  const [captureConsole, setCaptureConsole] = useState('')
+  const [captureScriptsLoading, setCaptureScriptsLoading] = useState(true)
+  const [captureScriptsError, setCaptureScriptsError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      fetch(IMPORT_CAPTURE_SCRIPTS.bookmarklet).then((r) => {
+        if (!r.ok) throw new Error(`bookmarklet ${r.status}`)
+        return r.text()
+      }),
+      fetch(IMPORT_CAPTURE_SCRIPTS.console).then((r) => {
+        if (!r.ok) throw new Error(`console ${r.status}`)
+        return r.text()
+      }),
+    ])
+      .then(([bm, cs]) => {
+        if (cancelled) return
+        setCaptureBookmarklet(bm)
+        setCaptureConsole(cs)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCaptureScriptsError('Could not load export scripts. Refresh the page or check that /js/import-*.js are deployed.')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setCaptureScriptsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const bookmarkletHref = captureBookmarklet ? `javascript:${encodeURIComponent(captureBookmarklet)}` : ''
 
   return (
     <div>
@@ -905,9 +708,21 @@ function InstructionsStep({ onFile, importSource, onLiveSynced }: { onFile: (fil
       {method === 'live' ? (
         <LiveImportTab onSynced={onLiveSynced} />
       ) : method === 'bookmarklet' ? (
-        <BookmarkletTab onFile={onFile} importSource={importSource} />
+        <BookmarkletTab
+          onFile={onFile}
+          importSource={importSource}
+          bookmarkletHref={bookmarkletHref}
+          captureScriptsLoading={captureScriptsLoading}
+          captureScriptsError={captureScriptsError}
+        />
       ) : (
-        <ConsoleTab onFile={onFile} importSource={importSource} />
+        <ConsoleTab
+          onFile={onFile}
+          importSource={importSource}
+          consoleScript={captureConsole}
+          captureScriptsLoading={captureScriptsLoading}
+          captureScriptsError={captureScriptsError}
+        />
       )}
     </div>
   )

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -1181,6 +1181,27 @@ export default function ImportPage() {
     const xOrigins = new Set(['https://x.com', 'https://twitter.com'])
     function onMessage(e: MessageEvent) {
       if (!xOrigins.has(e.origin)) return
+      if (e.data?.type === 'SIFTLY_LAST_JOB_FIRST_TIMELINE_QUERY') {
+        const win = e.source as Window | null
+        if (!win) return
+        const reply = (payload: {
+          bookmarkTweetId: string | null
+          likeTweetId: string | null
+        }) => {
+          win.postMessage({ type: 'SIFTLY_LAST_JOB_FIRST_TIMELINE_REPLY', ...payload }, e.origin)
+        }
+        void fetch('/api/import/last-job-first-timeline-tweets')
+          .then((r) => r.json())
+          .then((d: { bookmarkTweetId?: unknown; likeTweetId?: unknown }) => {
+            const bm = typeof d.bookmarkTweetId === 'string' && d.bookmarkTweetId ? d.bookmarkTweetId : null
+            const lk = typeof d.likeTweetId === 'string' && d.likeTweetId ? d.likeTweetId : null
+            reply({ bookmarkTweetId: bm, likeTweetId: lk })
+          })
+          .catch(() => {
+            reply({ bookmarkTweetId: null, likeTweetId: null })
+          })
+        return
+      }
       if (e.data?.type !== 'SIFTLY_BOOKMARK_CAPTURE' || !Array.isArray(e.data.bookmarks)) return
       const src = e.data.source === 'like' ? 'like' : 'bookmark'
       const json = JSON.stringify({ bookmarks: e.data.bookmarks, source: src }, null, 2)

--- a/public/js/import-bookmarklet.js
+++ b/public/js/import-bookmarklet.js
@@ -30,7 +30,12 @@
   function addTweet(t) {
     if (!t || !t.rest_id || seen.has(t.rest_id)) return;
     seen.add(t.rest_id);
-    var leg=t.legacy||{},usr=(t.core&&t.core.user_results&&t.core.user_results.result&&t.core.user_results.result.legacy)||{};
+    var leg = t.legacy || {};
+    var ur = (t.core && t.core.user_results && t.core.user_results.result) || {};
+    var uc = ur.core || {}, ul = ur.legacy || {};
+    var author = uc.name || ul.name || 'Unknown';
+    var handleSn = uc.screen_name || ul.screen_name || 'unknown';
+    var avatar = (ur.avatar && ur.avatar.image_url) || ul.profile_image_url_https || '';
     var rawMedia = (leg.extended_entities && leg.extended_entities.media) || (leg.entities && leg.entities.media) || [];
     var media = rawMedia.map(function (m) {
       var thumb = m.media_url_https || '';
@@ -44,8 +49,8 @@
       }
       return thumb ? { type: 'photo', url: thumb } : null;
     }).filter(Boolean);
-    all.push({id:t.rest_id,author:usr.name||'Unknown',handle:'@'+(usr.screen_name||'unknown'),
-      avatar:usr.profile_image_url_https||'',timestamp:leg.created_at||'',
+    all.push({ id: t.rest_id, author: author, handle: '@' + handleSn,
+      avatar: avatar, timestamp: leg.created_at || '',
       text: leg.full_text || leg.text || '', media: media,
       hashtags: (leg.entities && leg.entities.hashtags || []).map(function (h) { return h.text; }),
       urls: (leg.entities && leg.entities.urls || []).map(function (u) { return u.expanded_url; }).filter(Boolean)

--- a/public/js/import-bookmarklet.js
+++ b/public/js/import-bookmarklet.js
@@ -115,7 +115,17 @@
             autoScrolling = false;
             autoBtn.textContent = '✅ Done — ' + all.length + ' captured';
             autoBtn.style.background = '#14532d'; autoBtn.style.color = '#86efac'; autoBtn.style.border = '1px solid #166534';
-            showToast('✅ Auto-scroll complete! ' + all.length + ' ' + label + ' ready. Click Export.', '#14532d');
+            var sentToOpener = false;
+            try {
+              if (window.opener && !window.opener.closed) {
+                window.opener.postMessage({ type: 'SIFTLY_BOOKMARK_CAPTURE', bookmarks: all, source: source }, '*');
+                sentToOpener = true;
+                autoBtn.textContent = '✅ Done — ' + all.length + ' captured and importing to Siftly.';
+              }
+            } catch (ex) { }
+            showToast(sentToOpener
+              ? ('✅ Sent ' + all.length + ' ' + label + ' to Siftly.')
+              : ('✅ Auto-scroll complete! ' + all.length + ' ' + label + ' ready. Click Export.'), '#14532d');
             return;
           }
           stagnant = 0;

--- a/public/js/import-bookmarklet.js
+++ b/public/js/import-bookmarklet.js
@@ -18,6 +18,11 @@
     setTimeout(function () { t.style.opacity = '0'; setTimeout(function () { t.remove(); }, 300); }, 4000);
   }
   var all = [], seen = new Set();
+  var incrementalStopId = null;
+  var incrementalStopHit = false;
+  /** Length of `all` when incremental boundary was hit — trim tail in finishScrollCapture if async adds slip in. */
+  var incrementalStopSnapshotLen = null;
+  var lastImportedTweetIdFromOpener = null;
   var btn = document.createElement('button');
   btn.textContent = 'Scroll, then Export 0 ' + label + ' →';
   Object.assign(btn.style, {
@@ -28,7 +33,14 @@
     fontFamily: 'system-ui,sans-serif'
   });
   function addTweet(t) {
-    if (!t || !t.rest_id || seen.has(t.rest_id)) return;
+    if (!t || !t.rest_id) return;
+    if (incrementalStopHit) return;
+    if (incrementalStopId && t.rest_id === incrementalStopId) {
+      incrementalStopSnapshotLen = all.length;
+      incrementalStopHit = true;
+      return;
+    }
+    if (seen.has(t.rest_id)) return;
     seen.add(t.rest_id);
     var leg = t.legacy || {};
     var ur = (t.core && t.core.user_results && t.core.user_results.result) || {};
@@ -81,7 +93,7 @@
     XMLHttpRequest.prototype.open = origOpen;
     XMLHttpRequest.prototype.send = origSend;
     if (!all.length) { showToast('⚠️ No ' + label + ' captured — scroll or use Auto-scroll first!', '#92400e'); return; }
-    [btn, autoBtn].forEach(function (el) { try { document.body.removeChild(el); } catch (e) { } });
+    [btn, autoBtn, incBtn].forEach(function (el) { try { document.body.removeChild(el); } catch (e) { } });
     var blob = new Blob([JSON.stringify({ bookmarks: all, source: source }, null, 2)], { type: 'application/json' });
     var url = URL.createObjectURL(blob);
     var a = document.createElement('a'); a.href = url; a.download = source + 's.json'; a.click();
@@ -96,51 +108,110 @@
     border: '1px solid #3f3f46', borderRadius: '8px',
     cursor: 'pointer', fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
   });
+  var incBtn = document.createElement('button');
+  incBtn.textContent = '▶ Incremental-scroll';
+  Object.assign(incBtn.style, {
+    position: 'fixed', top: '58px', right: '130px', zIndex: '2147483647',
+    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
+    border: '1px solid #3f3f46', borderRadius: '8px',
+    cursor: 'pointer', fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
+  });
   var autoScrolling = false;
   function sleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
-  async function runAutoScroll() {
+  function resetScrollButtonsIdle() {
+    autoBtn.textContent = '▶ Auto-scroll';
+    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
+    incBtn.textContent = '▶ Incremental-scroll';
+    incBtn.style.background = '#18181b'; incBtn.style.color = '#a1a1aa'; incBtn.style.border = '1px solid #3f3f46';
+  }
+  function finishScrollCapture() {
+    var snapshotLen = incrementalStopSnapshotLen;
+    autoScrolling = false;
+    if (!all.length) {
+      incrementalStopId = null;
+      incrementalStopHit = false;
+      incrementalStopSnapshotLen = null;
+      resetScrollButtonsIdle();
+      showToast('⚠️ No ' + label + ' captured before stop.', '#92400e');
+      return;
+    }
+    if (snapshotLen !== null && snapshotLen < all.length) {
+      var tail = all.splice(snapshotLen);
+      tail.forEach(function (r) { seen.delete(r.id); });
+      btn.textContent = 'Export ' + all.length + ' ' + label + ' →';
+    }
+    incrementalStopId = null;
+    incrementalStopHit = false;
+    incrementalStopSnapshotLen = null;
+    autoBtn.textContent = '✅ Done — ' + all.length + ' captured';
+    autoBtn.style.background = '#14532d'; autoBtn.style.color = '#86efac'; autoBtn.style.border = '1px solid #166534';
+    incBtn.style.display = 'none';
+    var sentToOpener = false;
+    try {
+      if (window.opener && !window.opener.closed) {
+        window.opener.postMessage({ type: 'SIFTLY_BOOKMARK_CAPTURE', bookmarks: all, source: source }, '*');
+        sentToOpener = true;
+        autoBtn.textContent = '✅ Done — ' + all.length + ' captured and importing to Siftly.';
+      }
+    } catch (ex) { }
+    showToast(sentToOpener
+      ? ('✅ Sent ' + all.length + ' ' + label + ' to Siftly.')
+      : ('✅ Auto-scroll complete! ' + all.length + ' ' + label + ' ready. Click Export.'), '#14532d');
+  }
+  async function runAutoScroll(stopAfterTweetId) {
+    incrementalStopId = stopAfterTweetId ? String(stopAfterTweetId) : null;
+    incrementalStopHit = false;
+    incrementalStopSnapshotLen = null;
     var stagnant = 0, lastCount = all.length;
     while (autoScrolling) {
       window.scrollTo(0, document.documentElement.scrollHeight);
       var col = document.querySelector('[data-testid="primaryColumn"]');
       if (col) col.scrollTo(0, col.scrollHeight);
       await sleep(900);
+      if (incrementalStopHit) {
+        finishScrollCapture();
+        return;
+      }
       if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
       else {
         stagnant++;
         if (stagnant >= 8) {
           window.scrollTo(0, document.documentElement.scrollHeight);
           await sleep(2000);
+          if (incrementalStopHit) {
+            finishScrollCapture();
+            return;
+          }
           if (all.length === lastCount) {
-            autoScrolling = false;
-            autoBtn.textContent = '✅ Done — ' + all.length + ' captured';
-            autoBtn.style.background = '#14532d'; autoBtn.style.color = '#86efac'; autoBtn.style.border = '1px solid #166534';
-            var sentToOpener = false;
-            try {
-              if (window.opener && !window.opener.closed) {
-                window.opener.postMessage({ type: 'SIFTLY_BOOKMARK_CAPTURE', bookmarks: all, source: source }, '*');
-                sentToOpener = true;
-                autoBtn.textContent = '✅ Done — ' + all.length + ' captured and importing to Siftly.';
-              }
-            } catch (ex) { }
-            showToast(sentToOpener
-              ? ('✅ Sent ' + all.length + ' ' + label + ' to Siftly.')
-              : ('✅ Auto-scroll complete! ' + all.length + ' ' + label + ' ready. Click Export.'), '#14532d');
+            finishScrollCapture();
             return;
           }
           stagnant = 0;
         }
       }
     }
-    autoBtn.textContent = '▶ Auto-scroll';
-    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
+    incrementalStopId = null;
+    incrementalStopHit = false;
+    incrementalStopSnapshotLen = null;
+    resetScrollButtonsIdle();
   }
   autoBtn.onclick = function () {
     if (autoScrolling) { autoScrolling = false; return; }
     autoScrolling = true;
     autoBtn.textContent = '⏸ Stop';
     autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
-    runAutoScroll();
+    runAutoScroll(null);
+  };
+  incBtn.onclick = function () {
+    if (!lastImportedTweetIdFromOpener) {
+      showToast('⚠️ No last import ID — complete an import from Siftly first, or use full Auto-scroll.', '#92400e');
+      return;
+    }
+    if (autoScrolling) { autoScrolling = false; return; }
+    autoScrolling = true;
+    autoBtn.textContent = '⏸ Stop';
+    autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
+    runAutoScroll(lastImportedTweetIdFromOpener);
   };
   document.body.appendChild(btn);
   document.body.appendChild(autoBtn);
@@ -161,5 +232,24 @@
     if (isApiUrl(u)) { xhr.addEventListener('load', function () { try { processData(JSON.parse(xhr.responseText)); } catch (ex) { } }); }
     return origSend.apply(this, arguments);
   };
+  try {
+    if (window.opener && !window.opener.closed) {
+      function onLastIdReply(e) {
+        if (e.data && e.data.type === 'SIFTLY_LAST_JOB_FIRST_TIMELINE_REPLY') {
+          window.removeEventListener('message', onLastIdReply);
+          var tid = isLikes
+            ? (typeof e.data.likeTweetId === 'string' && e.data.likeTweetId ? e.data.likeTweetId : (typeof e.data.tweetId === 'string' ? e.data.tweetId : ''))
+            : (typeof e.data.bookmarkTweetId === 'string' && e.data.bookmarkTweetId ? e.data.bookmarkTweetId : (typeof e.data.tweetId === 'string' ? e.data.tweetId : ''));
+          if (tid) {
+            lastImportedTweetIdFromOpener = tid;
+            document.body.appendChild(incBtn);
+          }
+        }
+      }
+      window.addEventListener('message', onLastIdReply);
+      window.opener.postMessage({ type: 'SIFTLY_LAST_JOB_FIRST_TIMELINE_QUERY' }, '*');
+      setTimeout(function () { window.removeEventListener('message', onLastIdReply); }, 8000);
+    }
+  } catch (ex) { }
   showToast('✅ Active! Scroll your ' + label + ' — counter updates above.', '#1e1b4b');
 })();

--- a/public/js/import-bookmarklet.js
+++ b/public/js/import-bookmarklet.js
@@ -57,7 +57,11 @@
     });
     btn.textContent = 'Export ' + all.length + ' ' + label + ' →';
   }
-  function isTweetObj(o) { return o && typeof o === 'object' && typeof o.rest_id === 'string' && o.rest_id.length > 5 && (o.legacy || o.core); }
+  function isTweetObj(o) {
+    if (!o || typeof o !== 'object' || typeof o.rest_id !== 'string' || o.rest_id.length <= 5) return false;
+    var leg = o.legacy;
+    return !!(leg && (typeof leg.full_text === 'string' || typeof leg.text === 'string'));
+  }
   function unwrapTweet(t) {
     if (!t) return null;
     if (t.__typename === 'TweetWithVisibilityResults' || t.__typename === 'TweetWithVisibilityResult') return t.tweet || t;

--- a/public/js/import-bookmarklet.js
+++ b/public/js/import-bookmarklet.js
@@ -1,139 +1,146 @@
-(async function(){
-  if(!location.hostname.includes('twitter.com')&&!location.hostname.includes('x.com')){
-    showToast('❌ Please navigate to x.com/i/bookmarks or x.com/username/likes first','#ef4444');return;
+(async function () {
+  if (!location.hostname.includes('twitter.com') && !location.hostname.includes('x.com')) {
+    showToast('❌ Please navigate to x.com/i/bookmarks or x.com/username/likes first', '#ef4444'); return;
   }
-  var isLikes=location.pathname.includes('/likes');
-  var source=isLikes?'like':'bookmark';
-  var label=isLikes?'likes':'bookmarks';
-  function showToast(msg,bg){
-    var t=document.createElement('div');t.textContent=msg;
-    Object.assign(t.style,{position:'fixed',bottom:'24px',left:'50%',transform:'translateX(-50%)',
-      zIndex:'2147483647',padding:'10px 18px',background:bg||'#1e1b4b',color:'#fff',
-      border:'1px solid rgba(255,255,255,0.15)',borderRadius:'8px',
-      fontSize:'13px',fontWeight:'600',fontFamily:'system-ui,sans-serif',
-      boxShadow:'0 4px 20px rgba(0,0,0,0.6)',whiteSpace:'nowrap',transition:'opacity 0.3s'});
+  var isLikes = location.pathname.includes('/likes');
+  var source = isLikes ? 'like' : 'bookmark';
+  var label = isLikes ? 'likes' : 'bookmarks';
+  function showToast(msg, bg) {
+    var t = document.createElement('div'); t.textContent = msg;
+    Object.assign(t.style, {
+      position: 'fixed', bottom: '24px', left: '50%', transform: 'translateX(-50%)',
+      zIndex: '2147483647', padding: '10px 18px', background: bg || '#1e1b4b', color: '#fff',
+      border: '1px solid rgba(255,255,255,0.15)', borderRadius: '8px',
+      fontSize: '13px', fontWeight: '600', fontFamily: 'system-ui,sans-serif',
+      boxShadow: '0 4px 20px rgba(0,0,0,0.6)', whiteSpace: 'nowrap', transition: 'opacity 0.3s'
+    });
     document.body.appendChild(t);
-    setTimeout(function(){t.style.opacity='0';setTimeout(function(){t.remove();},300);},4000);
+    setTimeout(function () { t.style.opacity = '0'; setTimeout(function () { t.remove(); }, 300); }, 4000);
   }
-  var all=[],seen=new Set();
-  var btn=document.createElement('button');
-  btn.textContent='Scroll, then Export 0 '+label+' →';
-  Object.assign(btn.style,{position:'fixed',top:'12px',right:'12px',zIndex:'2147483647',
-    padding:'10px 18px',background:'#4f46e5',color:'#fff',border:'none',borderRadius:'8px',
-    cursor:'pointer',fontSize:'14px',fontWeight:'700',
-    boxShadow:'0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
-    fontFamily:'system-ui,sans-serif'});
-  function addTweet(t){
-    if(!t||!t.rest_id||seen.has(t.rest_id))return;
+  var all = [], seen = new Set();
+  var btn = document.createElement('button');
+  btn.textContent = 'Scroll, then Export 0 ' + label + ' →';
+  Object.assign(btn.style, {
+    position: 'fixed', top: '12px', right: '12px', zIndex: '2147483647',
+    padding: '10px 18px', background: '#4f46e5', color: '#fff', border: 'none', borderRadius: '8px',
+    cursor: 'pointer', fontSize: '14px', fontWeight: '700',
+    boxShadow: '0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
+    fontFamily: 'system-ui,sans-serif'
+  });
+  function addTweet(t) {
+    if (!t || !t.rest_id || seen.has(t.rest_id)) return;
     seen.add(t.rest_id);
     var leg=t.legacy||{},usr=(t.core&&t.core.user_results&&t.core.user_results.result&&t.core.user_results.result.legacy)||{};
-    var rawMedia=(leg.extended_entities&&leg.extended_entities.media)||(leg.entities&&leg.entities.media)||[];
-    var media=rawMedia.map(function(m){
-      var thumb=m.media_url_https||'';
-      if(m.type==='video'||m.type==='animated_gif'){
-        var variants=m.video_info&&m.video_info.variants||[];
-        var mp4s=variants.filter(function(v){return v.content_type==='video/mp4'&&v.url;}).sort(function(a,b){return(b.bitrate||0)-(a.bitrate||0);});
-        if(mp4s.length)return{type:m.type==='animated_gif'?'gif':'video',url:mp4s[0].url};
+    var rawMedia = (leg.extended_entities && leg.extended_entities.media) || (leg.entities && leg.entities.media) || [];
+    var media = rawMedia.map(function (m) {
+      var thumb = m.media_url_https || '';
+      if (m.type === 'video' || m.type === 'animated_gif') {
+        var variants = m.video_info && m.video_info.variants || [];
+        var mp4s = variants.filter(function (v) { return v.content_type === 'video/mp4' && v.url; }).sort(function (a, b) { return (b.bitrate || 0) - (a.bitrate || 0); });
+        if (mp4s.length) return { type: m.type === 'animated_gif' ? 'gif' : 'video', url: mp4s[0].url };
         // No mp4 — degrade to photo so thumbnail shows correctly (actual video not available)
-        if(thumb)return{type:'photo',url:thumb};
+        if (thumb) return { type: 'photo', url: thumb };
         return null;
       }
-      return thumb?{type:'photo',url:thumb}:null;
+      return thumb ? { type: 'photo', url: thumb } : null;
     }).filter(Boolean);
     all.push({id:t.rest_id,author:usr.name||'Unknown',handle:'@'+(usr.screen_name||'unknown'),
       avatar:usr.profile_image_url_https||'',timestamp:leg.created_at||'',
-      text:leg.full_text||leg.text||'',media:media,
-      hashtags:(leg.entities&&leg.entities.hashtags||[]).map(function(h){return h.text;}),
-      urls:(leg.entities&&leg.entities.urls||[]).map(function(u){return u.expanded_url;}).filter(Boolean)});
-    btn.textContent='Export '+all.length+' '+label+' →';
+      text: leg.full_text || leg.text || '', media: media,
+      hashtags: (leg.entities && leg.entities.hashtags || []).map(function (h) { return h.text; }),
+      urls: (leg.entities && leg.entities.urls || []).map(function (u) { return u.expanded_url; }).filter(Boolean)
+    });
+    btn.textContent = 'Export ' + all.length + ' ' + label + ' →';
   }
-  function isTweetObj(o){return o&&typeof o==='object'&&typeof o.rest_id==='string'&&o.rest_id.length>5&&(o.legacy||o.core);}
-  function unwrapTweet(t){
-    if(!t)return null;
-    if(t.__typename==='TweetWithVisibilityResults'||t.__typename==='TweetWithVisibilityResult')return t.tweet||t;
+  function isTweetObj(o) { return o && typeof o === 'object' && typeof o.rest_id === 'string' && o.rest_id.length > 5 && (o.legacy || o.core); }
+  function unwrapTweet(t) {
+    if (!t) return null;
+    if (t.__typename === 'TweetWithVisibilityResults' || t.__typename === 'TweetWithVisibilityResult') return t.tweet || t;
     return t;
   }
-  function deepFindTweets(obj,depth){
-    if(!obj||typeof obj!=='object'||depth>12)return;
-    if(Array.isArray(obj)){obj.forEach(function(item){deepFindTweets(item,depth+1);});return;}
-    if(obj.tweet_results&&obj.tweet_results.result){var tw=unwrapTweet(obj.tweet_results.result);if(tw)addTweet(tw);}
-    else if(isTweetObj(obj)){addTweet(unwrapTweet(obj));}
-    for(var k in obj){if(Object.prototype.hasOwnProperty.call(obj,k)&&k!=='quoted_status_result'){deepFindTweets(obj[k],depth+1);}}
+  function deepFindTweets(obj, depth) {
+    if (!obj || typeof obj !== 'object' || depth > 12) return;
+    if (Array.isArray(obj)) { obj.forEach(function (item) { deepFindTweets(item, depth + 1); }); return; }
+    if (obj.tweet_results && obj.tweet_results.result) { var tw = unwrapTweet(obj.tweet_results.result); if (tw) addTweet(tw); }
+    else if (isTweetObj(obj)) { addTweet(unwrapTweet(obj)); }
+    for (var k in obj) { if (Object.prototype.hasOwnProperty.call(obj, k) && k !== 'quoted_status_result') { deepFindTweets(obj[k], depth + 1); } }
   }
-  function processData(d){deepFindTweets(d,0);}
-  var autoBtn=document.createElement('button');
-  function doExport(){
-    window.fetch=origFetch;
-    XMLHttpRequest.prototype.open=origOpen;
-    XMLHttpRequest.prototype.send=origSend;
-    if(!all.length){showToast('⚠️ No '+label+' captured — scroll or use Auto-scroll first!','#92400e');return;}
-    [btn,autoBtn].forEach(function(el){try{document.body.removeChild(el);}catch(e){}});
-    var blob=new Blob([JSON.stringify({bookmarks:all,source:source},null,2)],{type:'application/json'});
-    var url=URL.createObjectURL(blob);
-    var a=document.createElement('a');a.href=url;a.download=source+'s.json';a.click();
-    setTimeout(function(){URL.revokeObjectURL(url);},1000);
-    showToast('✅ Downloaded '+all.length+' '+label+'! Upload to Siftly.','#14532d');
+  function processData(d) { deepFindTweets(d, 0); }
+  var autoBtn = document.createElement('button');
+  function doExport() {
+    window.fetch = origFetch;
+    XMLHttpRequest.prototype.open = origOpen;
+    XMLHttpRequest.prototype.send = origSend;
+    if (!all.length) { showToast('⚠️ No ' + label + ' captured — scroll or use Auto-scroll first!', '#92400e'); return; }
+    [btn, autoBtn].forEach(function (el) { try { document.body.removeChild(el); } catch (e) { } });
+    var blob = new Blob([JSON.stringify({ bookmarks: all, source: source }, null, 2)], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a'); a.href = url; a.download = source + 's.json'; a.click();
+    setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    showToast('✅ Downloaded ' + all.length + ' ' + label + '! Upload to Siftly.', '#14532d');
   }
-  btn.onclick=doExport;
-  autoBtn.textContent='▶ Auto-scroll';
-  Object.assign(autoBtn.style,{position:'fixed',top:'58px',right:'12px',zIndex:'2147483647',
-    padding:'8px 14px',background:'#18181b',color:'#a1a1aa',
-    border:'1px solid #3f3f46',borderRadius:'8px',
-    cursor:'pointer',fontSize:'12px',fontWeight:'600',fontFamily:'system-ui,sans-serif'});
-  var autoScrolling=false;
-  function sleep(ms){return new Promise(function(r){setTimeout(r,ms);});}
-  async function runAutoScroll(){
-    var stagnant=0,lastCount=all.length;
-    while(autoScrolling){
-      window.scrollTo(0,document.documentElement.scrollHeight);
-      var col=document.querySelector('[data-testid="primaryColumn"]');
-      if(col)col.scrollTo(0,col.scrollHeight);
+  btn.onclick = doExport;
+  autoBtn.textContent = '▶ Auto-scroll';
+  Object.assign(autoBtn.style, {
+    position: 'fixed', top: '58px', right: '12px', zIndex: '2147483647',
+    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
+    border: '1px solid #3f3f46', borderRadius: '8px',
+    cursor: 'pointer', fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
+  });
+  var autoScrolling = false;
+  function sleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
+  async function runAutoScroll() {
+    var stagnant = 0, lastCount = all.length;
+    while (autoScrolling) {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      var col = document.querySelector('[data-testid="primaryColumn"]');
+      if (col) col.scrollTo(0, col.scrollHeight);
       await sleep(900);
-      if(all.length>lastCount){stagnant=0;lastCount=all.length;}
-      else{
+      if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
+      else {
         stagnant++;
-        if(stagnant>=8){
-          window.scrollTo(0,document.documentElement.scrollHeight);
+        if (stagnant >= 8) {
+          window.scrollTo(0, document.documentElement.scrollHeight);
           await sleep(2000);
-          if(all.length===lastCount){
-            autoScrolling=false;
-            autoBtn.textContent='✅ Done — '+all.length+' captured';
-            autoBtn.style.background='#14532d';autoBtn.style.color='#86efac';autoBtn.style.border='1px solid #166534';
-            showToast('✅ Auto-scroll complete! '+all.length+' '+label+' ready. Click Export.','#14532d');
+          if (all.length === lastCount) {
+            autoScrolling = false;
+            autoBtn.textContent = '✅ Done — ' + all.length + ' captured';
+            autoBtn.style.background = '#14532d'; autoBtn.style.color = '#86efac'; autoBtn.style.border = '1px solid #166534';
+            showToast('✅ Auto-scroll complete! ' + all.length + ' ' + label + ' ready. Click Export.', '#14532d');
             return;
           }
-          stagnant=0;
+          stagnant = 0;
         }
       }
     }
-    autoBtn.textContent='▶ Auto-scroll';
-    autoBtn.style.background='#18181b';autoBtn.style.color='#a1a1aa';autoBtn.style.border='1px solid #3f3f46';
+    autoBtn.textContent = '▶ Auto-scroll';
+    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
   }
-  autoBtn.onclick=function(){
-    if(autoScrolling){autoScrolling=false;return;}
-    autoScrolling=true;
-    autoBtn.textContent='⏸ Stop';
-    autoBtn.style.background='#4f46e5';autoBtn.style.color='#fff';autoBtn.style.border='none';
+  autoBtn.onclick = function () {
+    if (autoScrolling) { autoScrolling = false; return; }
+    autoScrolling = true;
+    autoBtn.textContent = '⏸ Stop';
+    autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
     runAutoScroll();
   };
   document.body.appendChild(btn);
   document.body.appendChild(autoBtn);
-  function isApiUrl(u){return u.includes('/graphql/')||u.includes('/i/api/')||u.includes('/2/timeline');}
-  var origFetch=window.fetch;
-  window.fetch=async function(){
-    var r=await origFetch.apply(this,arguments);
-    try{
-      var u=arguments[0] instanceof Request?arguments[0].url:String(arguments[0]);
-      if(isApiUrl(u)){var ct=r.headers.get('content-type')||'';if(ct.includes('json')){var d=await r.clone().json();processData(d);}}
-    }catch(ex){}
+  function isApiUrl(u) { return u.includes('/graphql/') || u.includes('/i/api/') || u.includes('/2/timeline'); }
+  var origFetch = window.fetch;
+  window.fetch = async function () {
+    var r = await origFetch.apply(this, arguments);
+    try {
+      var u = arguments[0] instanceof Request ? arguments[0].url : String(arguments[0]);
+      if (isApiUrl(u)) { var ct = r.headers.get('content-type') || ''; if (ct.includes('json')) { var d = await r.clone().json(); processData(d); } }
+    } catch (ex) { }
     return r;
   };
-  var origOpen=XMLHttpRequest.prototype.open,origSend=XMLHttpRequest.prototype.send,xhrUrls=new WeakMap();
-  XMLHttpRequest.prototype.open=function(){xhrUrls.set(this,String(arguments[1]||''));return origOpen.apply(this,arguments);};
-  XMLHttpRequest.prototype.send=function(){
-    var xhr=this,u=xhrUrls.get(xhr)||'';
-    if(isApiUrl(u)){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
-    return origSend.apply(this,arguments);
+  var origOpen = XMLHttpRequest.prototype.open, origSend = XMLHttpRequest.prototype.send, xhrUrls = new WeakMap();
+  XMLHttpRequest.prototype.open = function () { xhrUrls.set(this, String(arguments[1] || '')); return origOpen.apply(this, arguments); };
+  XMLHttpRequest.prototype.send = function () {
+    var xhr = this, u = xhrUrls.get(xhr) || '';
+    if (isApiUrl(u)) { xhr.addEventListener('load', function () { try { processData(JSON.parse(xhr.responseText)); } catch (ex) { } }); }
+    return origSend.apply(this, arguments);
   };
-  showToast('✅ Active! Scroll your '+label+' — counter updates above.','#1e1b4b');
+  showToast('✅ Active! Scroll your ' + label + ' — counter updates above.', '#1e1b4b');
 })();

--- a/public/js/import-bookmarklet.js
+++ b/public/js/import-bookmarklet.js
@@ -1,0 +1,139 @@
+(async function(){
+  if(!location.hostname.includes('twitter.com')&&!location.hostname.includes('x.com')){
+    showToast('❌ Please navigate to x.com/i/bookmarks or x.com/username/likes first','#ef4444');return;
+  }
+  var isLikes=location.pathname.includes('/likes');
+  var source=isLikes?'like':'bookmark';
+  var label=isLikes?'likes':'bookmarks';
+  function showToast(msg,bg){
+    var t=document.createElement('div');t.textContent=msg;
+    Object.assign(t.style,{position:'fixed',bottom:'24px',left:'50%',transform:'translateX(-50%)',
+      zIndex:'2147483647',padding:'10px 18px',background:bg||'#1e1b4b',color:'#fff',
+      border:'1px solid rgba(255,255,255,0.15)',borderRadius:'8px',
+      fontSize:'13px',fontWeight:'600',fontFamily:'system-ui,sans-serif',
+      boxShadow:'0 4px 20px rgba(0,0,0,0.6)',whiteSpace:'nowrap',transition:'opacity 0.3s'});
+    document.body.appendChild(t);
+    setTimeout(function(){t.style.opacity='0';setTimeout(function(){t.remove();},300);},4000);
+  }
+  var all=[],seen=new Set();
+  var btn=document.createElement('button');
+  btn.textContent='Scroll, then Export 0 '+label+' →';
+  Object.assign(btn.style,{position:'fixed',top:'12px',right:'12px',zIndex:'2147483647',
+    padding:'10px 18px',background:'#4f46e5',color:'#fff',border:'none',borderRadius:'8px',
+    cursor:'pointer',fontSize:'14px',fontWeight:'700',
+    boxShadow:'0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
+    fontFamily:'system-ui,sans-serif'});
+  function addTweet(t){
+    if(!t||!t.rest_id||seen.has(t.rest_id))return;
+    seen.add(t.rest_id);
+    var leg=t.legacy||{},usr=(t.core&&t.core.user_results&&t.core.user_results.result&&t.core.user_results.result.legacy)||{};
+    var rawMedia=(leg.extended_entities&&leg.extended_entities.media)||(leg.entities&&leg.entities.media)||[];
+    var media=rawMedia.map(function(m){
+      var thumb=m.media_url_https||'';
+      if(m.type==='video'||m.type==='animated_gif'){
+        var variants=m.video_info&&m.video_info.variants||[];
+        var mp4s=variants.filter(function(v){return v.content_type==='video/mp4'&&v.url;}).sort(function(a,b){return(b.bitrate||0)-(a.bitrate||0);});
+        if(mp4s.length)return{type:m.type==='animated_gif'?'gif':'video',url:mp4s[0].url};
+        // No mp4 — degrade to photo so thumbnail shows correctly (actual video not available)
+        if(thumb)return{type:'photo',url:thumb};
+        return null;
+      }
+      return thumb?{type:'photo',url:thumb}:null;
+    }).filter(Boolean);
+    all.push({id:t.rest_id,author:usr.name||'Unknown',handle:'@'+(usr.screen_name||'unknown'),
+      avatar:usr.profile_image_url_https||'',timestamp:leg.created_at||'',
+      text:leg.full_text||leg.text||'',media:media,
+      hashtags:(leg.entities&&leg.entities.hashtags||[]).map(function(h){return h.text;}),
+      urls:(leg.entities&&leg.entities.urls||[]).map(function(u){return u.expanded_url;}).filter(Boolean)});
+    btn.textContent='Export '+all.length+' '+label+' →';
+  }
+  function isTweetObj(o){return o&&typeof o==='object'&&typeof o.rest_id==='string'&&o.rest_id.length>5&&(o.legacy||o.core);}
+  function unwrapTweet(t){
+    if(!t)return null;
+    if(t.__typename==='TweetWithVisibilityResults'||t.__typename==='TweetWithVisibilityResult')return t.tweet||t;
+    return t;
+  }
+  function deepFindTweets(obj,depth){
+    if(!obj||typeof obj!=='object'||depth>12)return;
+    if(Array.isArray(obj)){obj.forEach(function(item){deepFindTweets(item,depth+1);});return;}
+    if(obj.tweet_results&&obj.tweet_results.result){var tw=unwrapTweet(obj.tweet_results.result);if(tw)addTweet(tw);}
+    else if(isTweetObj(obj)){addTweet(unwrapTweet(obj));}
+    for(var k in obj){if(Object.prototype.hasOwnProperty.call(obj,k)&&k!=='quoted_status_result'){deepFindTweets(obj[k],depth+1);}}
+  }
+  function processData(d){deepFindTweets(d,0);}
+  var autoBtn=document.createElement('button');
+  function doExport(){
+    window.fetch=origFetch;
+    XMLHttpRequest.prototype.open=origOpen;
+    XMLHttpRequest.prototype.send=origSend;
+    if(!all.length){showToast('⚠️ No '+label+' captured — scroll or use Auto-scroll first!','#92400e');return;}
+    [btn,autoBtn].forEach(function(el){try{document.body.removeChild(el);}catch(e){}});
+    var blob=new Blob([JSON.stringify({bookmarks:all,source:source},null,2)],{type:'application/json'});
+    var url=URL.createObjectURL(blob);
+    var a=document.createElement('a');a.href=url;a.download=source+'s.json';a.click();
+    setTimeout(function(){URL.revokeObjectURL(url);},1000);
+    showToast('✅ Downloaded '+all.length+' '+label+'! Upload to Siftly.','#14532d');
+  }
+  btn.onclick=doExport;
+  autoBtn.textContent='▶ Auto-scroll';
+  Object.assign(autoBtn.style,{position:'fixed',top:'58px',right:'12px',zIndex:'2147483647',
+    padding:'8px 14px',background:'#18181b',color:'#a1a1aa',
+    border:'1px solid #3f3f46',borderRadius:'8px',
+    cursor:'pointer',fontSize:'12px',fontWeight:'600',fontFamily:'system-ui,sans-serif'});
+  var autoScrolling=false;
+  function sleep(ms){return new Promise(function(r){setTimeout(r,ms);});}
+  async function runAutoScroll(){
+    var stagnant=0,lastCount=all.length;
+    while(autoScrolling){
+      window.scrollTo(0,document.documentElement.scrollHeight);
+      var col=document.querySelector('[data-testid="primaryColumn"]');
+      if(col)col.scrollTo(0,col.scrollHeight);
+      await sleep(900);
+      if(all.length>lastCount){stagnant=0;lastCount=all.length;}
+      else{
+        stagnant++;
+        if(stagnant>=8){
+          window.scrollTo(0,document.documentElement.scrollHeight);
+          await sleep(2000);
+          if(all.length===lastCount){
+            autoScrolling=false;
+            autoBtn.textContent='✅ Done — '+all.length+' captured';
+            autoBtn.style.background='#14532d';autoBtn.style.color='#86efac';autoBtn.style.border='1px solid #166534';
+            showToast('✅ Auto-scroll complete! '+all.length+' '+label+' ready. Click Export.','#14532d');
+            return;
+          }
+          stagnant=0;
+        }
+      }
+    }
+    autoBtn.textContent='▶ Auto-scroll';
+    autoBtn.style.background='#18181b';autoBtn.style.color='#a1a1aa';autoBtn.style.border='1px solid #3f3f46';
+  }
+  autoBtn.onclick=function(){
+    if(autoScrolling){autoScrolling=false;return;}
+    autoScrolling=true;
+    autoBtn.textContent='⏸ Stop';
+    autoBtn.style.background='#4f46e5';autoBtn.style.color='#fff';autoBtn.style.border='none';
+    runAutoScroll();
+  };
+  document.body.appendChild(btn);
+  document.body.appendChild(autoBtn);
+  function isApiUrl(u){return u.includes('/graphql/')||u.includes('/i/api/')||u.includes('/2/timeline');}
+  var origFetch=window.fetch;
+  window.fetch=async function(){
+    var r=await origFetch.apply(this,arguments);
+    try{
+      var u=arguments[0] instanceof Request?arguments[0].url:String(arguments[0]);
+      if(isApiUrl(u)){var ct=r.headers.get('content-type')||'';if(ct.includes('json')){var d=await r.clone().json();processData(d);}}
+    }catch(ex){}
+    return r;
+  };
+  var origOpen=XMLHttpRequest.prototype.open,origSend=XMLHttpRequest.prototype.send,xhrUrls=new WeakMap();
+  XMLHttpRequest.prototype.open=function(){xhrUrls.set(this,String(arguments[1]||''));return origOpen.apply(this,arguments);};
+  XMLHttpRequest.prototype.send=function(){
+    var xhr=this,u=xhrUrls.get(xhr)||'';
+    if(isApiUrl(u)){xhr.addEventListener('load',function(){try{processData(JSON.parse(xhr.responseText));}catch(ex){}});}
+    return origSend.apply(this,arguments);
+  };
+  showToast('✅ Active! Scroll your '+label+' — counter updates above.','#1e1b4b');
+})();

--- a/public/js/import-console.js
+++ b/public/js/import-console.js
@@ -104,7 +104,17 @@
             autoScrolling = false;
             autoBtn.textContent = `✅ Done — ${all.length} captured`;
             autoBtn.style.cssText += ';background:#14532d;color:#86efac;border:1px solid #166534';
-            console.log(`✅ Auto-scroll complete! ${all.length} ${label} ready. Click Export.`);
+            let sentToOpener = false;
+            try {
+              if (window.opener && !window.opener.closed) {
+                window.opener.postMessage({ type: 'SIFTLY_BOOKMARK_CAPTURE', bookmarks: all, source }, '*');
+                sentToOpener = true;
+                autoBtn.textContent = `✅ Done — ${all.length} captured and importing to Siftly.`;
+              }
+            } catch { /* ignore */ }
+            console.log(sentToOpener
+              ? `✅ Sent ${all.length} ${label} to Siftly.`
+              : `✅ Auto-scroll complete! ${all.length} ${label} ready. Click Export.`);
             return;
           }
           stagnant = 0;

--- a/public/js/import-console.js
+++ b/public/js/import-console.js
@@ -9,7 +9,13 @@
   function addTweet(t) {
     if (!t?.rest_id || seen.has(t.rest_id)) return;
     seen.add(t.rest_id);
-    const leg = t.legacy ?? {}, usr = t.core?.user_results?.result?.legacy ?? {};
+    const leg = t.legacy ?? {};
+    const ur = t.core?.user_results?.result ?? {};
+    const uc = ur.core ?? {};
+    const ul = ur.legacy ?? {};
+    const author = uc.name ?? ul.name ?? 'Unknown';
+    const handleSn = uc.screen_name ?? ul.screen_name ?? 'unknown';
+    const avatar = ur.avatar?.image_url ?? ul.profile_image_url_https ?? '';
     const media = (leg.extended_entities?.media ?? leg.entities?.media ?? []).map(m => {
       const thumb = m.media_url_https ?? '';
       if (m.type === 'video' || m.type === 'animated_gif') {
@@ -22,7 +28,7 @@
       return thumb ? { type: 'photo', url: thumb } : null;
     }).filter(Boolean);
     all.push({
-      id: t.rest_id, author: usr.name ?? 'Unknown', handle: '@' + (usr.screen_name ?? 'unknown'),
+      id: t.rest_id, author, handle: '@' + handleSn, avatar,
       timestamp: leg.created_at ?? '', text: leg.full_text ?? leg.text ?? '', media,
       hashtags: (leg.entities?.hashtags ?? []).map(h => h.text),
       urls: (leg.entities?.urls ?? []).map(u => u.expanded_url).filter(Boolean)

--- a/public/js/import-console.js
+++ b/public/js/import-console.js
@@ -35,7 +35,11 @@
     });
     btn.textContent = `Export ${all.length} ${label} →`;
   }
-  function isTweetObj(o) { return o && typeof o === 'object' && typeof o.rest_id === 'string' && o.rest_id.length > 5 && (o.legacy || o.core); }
+  function isTweetObj(o) {
+    if (!o || typeof o !== 'object' || typeof o.rest_id !== 'string' || o.rest_id.length <= 5) return false;
+    const leg = o.legacy;
+    return !!(leg && (typeof leg.full_text === 'string' || typeof leg.text === 'string'));
+  }
   function unwrapTweet(t) {
     if (!t) return null;
     if (t.__typename === 'TweetWithVisibilityResults' || t.__typename === 'TweetWithVisibilityResult') return t.tweet ?? t;

--- a/public/js/import-console.js
+++ b/public/js/import-console.js
@@ -1,0 +1,143 @@
+(async function() {
+  if (!location.hostname.includes('twitter.com') && !location.hostname.includes('x.com')) {
+    alert('Run this on x.com/i/bookmarks or x.com/username/likes'); return;
+  }
+  const isLikes = location.pathname.includes('/likes');
+  const source = isLikes ? 'like' : 'bookmark';
+  const label = isLikes ? 'likes' : 'bookmarks';
+  const all = [], seen = new Set();
+  function addTweet(t) {
+    if (!t?.rest_id || seen.has(t.rest_id)) return;
+    seen.add(t.rest_id);
+    const leg = t.legacy ?? {}, usr = t.core?.user_results?.result?.legacy ?? {};
+    const media = (leg.extended_entities?.media ?? leg.entities?.media ?? []).map(m => {
+      const thumb = m.media_url_https ?? '';
+      if (m.type === 'video' || m.type === 'animated_gif') {
+        const mp4s = (m.video_info?.variants ?? []).filter(v => v.content_type === 'video/mp4' && v.url)
+          .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
+        if (mp4s.length) return { type: m.type === 'animated_gif' ? 'gif' : 'video', url: mp4s[0].url };
+        // No mp4 — degrade to photo so thumbnail shows correctly (actual video not available)
+        return thumb ? { type: 'photo', url: thumb } : null;
+      }
+      return thumb ? { type: 'photo', url: thumb } : null;
+    }).filter(Boolean);
+    all.push({
+      id: t.rest_id, author: usr.name ?? 'Unknown', handle: '@' + (usr.screen_name ?? 'unknown'),
+      timestamp: leg.created_at ?? '', text: leg.full_text ?? leg.text ?? '', media,
+      hashtags: (leg.entities?.hashtags ?? []).map(h => h.text),
+      urls: (leg.entities?.urls ?? []).map(u => u.expanded_url).filter(Boolean)
+    });
+    btn.textContent = `Export ${all.length} ${label} →`;
+  }
+  function isTweetObj(o) { return o && typeof o === 'object' && typeof o.rest_id === 'string' && o.rest_id.length > 5 && (o.legacy || o.core); }
+  function unwrapTweet(t) {
+    if (!t) return null;
+    if (t.__typename === 'TweetWithVisibilityResults' || t.__typename === 'TweetWithVisibilityResult') return t.tweet ?? t;
+    return t;
+  }
+  function deepFindTweets(obj, depth = 0) {
+    if (!obj || typeof obj !== 'object' || depth > 12) return;
+    if (Array.isArray(obj)) { obj.forEach(item => deepFindTweets(item, depth + 1)); return; }
+    if (obj.tweet_results?.result) { const tw = unwrapTweet(obj.tweet_results.result); if (tw) addTweet(tw); }
+    else if (isTweetObj(obj)) { addTweet(unwrapTweet(obj)); }
+    for (const k of Object.keys(obj)) { if (k !== 'quoted_status_result') deepFindTweets(obj[k], depth + 1); }
+  }
+  function processData(d) { deepFindTweets(d, 0); }
+  const btn = document.createElement('button');
+  btn.textContent = 'Scroll then click to Export →';
+  Object.assign(btn.style, {
+    position: 'fixed', top: '12px', right: '12px', zIndex: '2147483647',
+    padding: '10px 18px', background: '#4f46e5', color: '#fff',
+    border: 'none', borderRadius: '8px', cursor: 'pointer',
+    fontSize: '14px', fontWeight: '700',
+    boxShadow: '0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
+    fontFamily: 'system-ui,sans-serif'
+  });
+  function doExport() {
+    window.fetch = origFetch;
+    XMLHttpRequest.prototype.open = origOpen;
+    XMLHttpRequest.prototype.send = origSend;
+    [btn, autoBtn].forEach(el => { try { document.body.removeChild(el); } catch(e) {} });
+    if (!all.length) { alert(`No ${label} captured. Use Auto-scroll or scroll manually first.`); return; }
+    const blob = new Blob([JSON.stringify({ bookmarks: all, source }, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `${source}s.json`; a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    console.log(`✅ Downloaded ${all.length} ${label}!`);
+  }
+  btn.onclick = doExport;
+  const autoBtn = document.createElement('button');
+  autoBtn.textContent = '▶ Auto-scroll';
+  Object.assign(autoBtn.style, {
+    position: 'fixed', top: '58px', right: '12px', zIndex: '2147483647',
+    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
+    border: '1px solid #3f3f46', borderRadius: '8px', cursor: 'pointer',
+    fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
+  });
+  let autoScrolling = false;
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+  async function runAutoScroll() {
+    let stagnant = 0, lastCount = all.length;
+    while (autoScrolling) {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      const col = document.querySelector('[data-testid="primaryColumn"]');
+      col?.scrollTo(0, col.scrollHeight);
+      await sleep(900);
+      if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
+      else {
+        stagnant++;
+        if (stagnant >= 8) {
+          window.scrollTo(0, document.documentElement.scrollHeight);
+          await sleep(2000);
+          if (all.length === lastCount) {
+            autoScrolling = false;
+            autoBtn.textContent = `✅ Done — ${all.length} captured`;
+            autoBtn.style.cssText += ';background:#14532d;color:#86efac;border:1px solid #166534';
+            console.log(`✅ Auto-scroll complete! ${all.length} ${label} ready. Click Export.`);
+            return;
+          }
+          stagnant = 0;
+        }
+      }
+    }
+    autoBtn.textContent = '▶ Auto-scroll';
+    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
+  }
+  autoBtn.onclick = function() {
+    if (autoScrolling) { autoScrolling = false; return; }
+    autoScrolling = true;
+    autoBtn.textContent = '⏸ Stop';
+    autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
+    runAutoScroll();
+  };
+  document.body.appendChild(btn);
+  document.body.appendChild(autoBtn);
+  const isApiUrl = (u) => u.includes('/graphql/') || u.includes('/i/api/') || u.includes('/2/timeline');
+  const origFetch = window.fetch;
+  window.fetch = async function(...args) {
+    const r = await origFetch.apply(this, args);
+    try {
+      const u = args[0] instanceof Request ? args[0].url : String(args[0]);
+      if (isApiUrl(u)) { const ct = r.headers.get('content-type') ?? ''; if (ct.includes('json')) { const d = await r.clone().json(); processData(d); } }
+    } catch(e) {}
+    return r;
+  };
+  const origOpen = XMLHttpRequest.prototype.open;
+  const origSend = XMLHttpRequest.prototype.send;
+  const xhrUrls = new WeakMap();
+  XMLHttpRequest.prototype.open = function(...args) {
+    xhrUrls.set(this, String(args[1] ?? ''));
+    return origOpen.apply(this, args);
+  };
+  XMLHttpRequest.prototype.send = function(...args) {
+    const xhr = this, u = xhrUrls.get(xhr) ?? '';
+    if (isApiUrl(u)) {
+      xhr.addEventListener('load', function() {
+        try { processData(JSON.parse(xhr.responseText)); } catch(e) {}
+      });
+    }
+    return origSend.apply(this, args);
+  };
+  console.log(`✅ Script active. Scroll through your ${label}, then click the purple button.`);
+})();

--- a/public/js/import-console.js
+++ b/public/js/import-console.js
@@ -1,4 +1,4 @@
-(async function() {
+(async function () {
   if (!location.hostname.includes('twitter.com') && !location.hostname.includes('x.com')) {
     alert('Run this on x.com/i/bookmarks or x.com/username/likes'); return;
   }
@@ -57,7 +57,7 @@
     window.fetch = origFetch;
     XMLHttpRequest.prototype.open = origOpen;
     XMLHttpRequest.prototype.send = origSend;
-    [btn, autoBtn].forEach(el => { try { document.body.removeChild(el); } catch(e) {} });
+    [btn, autoBtn].forEach(el => { try { document.body.removeChild(el); } catch (e) { } });
     if (!all.length) { alert(`No ${label} captured. Use Auto-scroll or scroll manually first.`); return; }
     const blob = new Blob([JSON.stringify({ bookmarks: all, source }, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -104,7 +104,7 @@
     autoBtn.textContent = '▶ Auto-scroll';
     autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
   }
-  autoBtn.onclick = function() {
+  autoBtn.onclick = function () {
     if (autoScrolling) { autoScrolling = false; return; }
     autoScrolling = true;
     autoBtn.textContent = '⏸ Stop';
@@ -115,26 +115,26 @@
   document.body.appendChild(autoBtn);
   const isApiUrl = (u) => u.includes('/graphql/') || u.includes('/i/api/') || u.includes('/2/timeline');
   const origFetch = window.fetch;
-  window.fetch = async function(...args) {
+  window.fetch = async function (...args) {
     const r = await origFetch.apply(this, args);
     try {
       const u = args[0] instanceof Request ? args[0].url : String(args[0]);
       if (isApiUrl(u)) { const ct = r.headers.get('content-type') ?? ''; if (ct.includes('json')) { const d = await r.clone().json(); processData(d); } }
-    } catch(e) {}
+    } catch (e) { }
     return r;
   };
   const origOpen = XMLHttpRequest.prototype.open;
   const origSend = XMLHttpRequest.prototype.send;
   const xhrUrls = new WeakMap();
-  XMLHttpRequest.prototype.open = function(...args) {
+  XMLHttpRequest.prototype.open = function (...args) {
     xhrUrls.set(this, String(args[1] ?? ''));
     return origOpen.apply(this, args);
   };
-  XMLHttpRequest.prototype.send = function(...args) {
+  XMLHttpRequest.prototype.send = function (...args) {
     const xhr = this, u = xhrUrls.get(xhr) ?? '';
     if (isApiUrl(u)) {
-      xhr.addEventListener('load', function() {
-        try { processData(JSON.parse(xhr.responseText)); } catch(e) {}
+      xhr.addEventListener('load', function () {
+        try { processData(JSON.parse(xhr.responseText)); } catch (e) { }
       });
     }
     return origSend.apply(this, args);

--- a/public/js/import-console.js
+++ b/public/js/import-console.js
@@ -6,8 +6,20 @@
   const source = isLikes ? 'like' : 'bookmark';
   const label = isLikes ? 'likes' : 'bookmarks';
   const all = [], seen = new Set();
+  let incrementalStopId = null;
+  let incrementalStopHit = false;
+  /** Length of `all` when incremental boundary was hit — trim tail in finishScrollCapture if async adds slip in. */
+  let incrementalStopSnapshotLen = null;
+  let lastImportedTweetIdFromOpener = null;
   function addTweet(t) {
-    if (!t?.rest_id || seen.has(t.rest_id)) return;
+    if (!t?.rest_id) return;
+    if (incrementalStopHit) return;
+    if (incrementalStopId && t.rest_id === incrementalStopId) {
+      incrementalStopSnapshotLen = all.length;
+      incrementalStopHit = true;
+      return;
+    }
+    if (seen.has(t.rest_id)) return;
     seen.add(t.rest_id);
     const leg = t.legacy ?? {};
     const ur = t.core?.user_results?.result ?? {};
@@ -63,11 +75,109 @@
     boxShadow: '0 0 0 2px rgba(99,102,241,.4),0 4px 16px rgba(0,0,0,.4)',
     fontFamily: 'system-ui,sans-serif'
   });
+  const autoBtn = document.createElement('button');
+  autoBtn.textContent = '▶ Auto-scroll';
+  Object.assign(autoBtn.style, {
+    position: 'fixed', top: '58px', right: '12px', zIndex: '2147483647',
+    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
+    border: '1px solid #3f3f46', borderRadius: '8px', cursor: 'pointer',
+    fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
+  });
+  const incBtn = document.createElement('button');
+  incBtn.textContent = '▶ Incremental';
+  Object.assign(incBtn.style, {
+    position: 'fixed', top: '104px', right: '12px', zIndex: '2147483647',
+    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
+    border: '1px solid #3f3f46', borderRadius: '8px', cursor: 'pointer',
+    fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
+  });
+  let autoScrolling = false;
+  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+  function resetScrollButtonsIdle() {
+    autoBtn.textContent = '▶ Auto-scroll';
+    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
+    incBtn.textContent = '▶ Incremental';
+    incBtn.style.background = '#18181b'; incBtn.style.color = '#a1a1aa'; incBtn.style.border = '1px solid #3f3f46';
+  }
+  function finishScrollCapture() {
+    const snapshotLen = incrementalStopSnapshotLen;
+    autoScrolling = false;
+    if (!all.length) {
+      incrementalStopId = null;
+      incrementalStopHit = false;
+      incrementalStopSnapshotLen = null;
+      resetScrollButtonsIdle();
+      console.warn(`No ${label} captured before stop.`);
+      return;
+    }
+    if (snapshotLen !== null && snapshotLen < all.length) {
+      const tail = all.splice(snapshotLen);
+      tail.forEach((r) => { seen.delete(r.id); });
+      btn.textContent = `Export ${all.length} ${label} →`;
+    }
+    incrementalStopId = null;
+    incrementalStopHit = false;
+    incrementalStopSnapshotLen = null;
+    autoBtn.textContent = `✅ Done — ${all.length} captured`;
+    autoBtn.style.background = '#14532d';
+    autoBtn.style.color = '#86efac';
+    autoBtn.style.border = '1px solid #166534';
+    incBtn.textContent = '▶ Incremental';
+    incBtn.style.background = '#18181b'; incBtn.style.color = '#a1a1aa'; incBtn.style.border = '1px solid #3f3f46';
+    let sentToOpener = false;
+    try {
+      if (window.opener && !window.opener.closed) {
+        window.opener.postMessage({ type: 'SIFTLY_BOOKMARK_CAPTURE', bookmarks: all, source }, '*');
+        sentToOpener = true;
+        autoBtn.textContent = `✅ Done — ${all.length} captured and importing to Siftly.`;
+      }
+    } catch { /* ignore */ }
+    console.log(sentToOpener
+      ? `✅ Sent ${all.length} ${label} to Siftly.`
+      : `✅ Auto-scroll complete! ${all.length} ${label} ready. Click Export.`);
+  }
+  async function runAutoScroll(stopAfterTweetId) {
+    incrementalStopId = stopAfterTweetId ? String(stopAfterTweetId) : null;
+    incrementalStopHit = false;
+    incrementalStopSnapshotLen = null;
+    let stagnant = 0, lastCount = all.length;
+    while (autoScrolling) {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      const col = document.querySelector('[data-testid="primaryColumn"]');
+      col?.scrollTo(0, col.scrollHeight);
+      await sleep(900);
+      if (incrementalStopHit) {
+        finishScrollCapture();
+        return;
+      }
+      if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
+      else {
+        stagnant++;
+        if (stagnant >= 8) {
+          window.scrollTo(0, document.documentElement.scrollHeight);
+          await sleep(2000);
+          if (incrementalStopHit) {
+            finishScrollCapture();
+            return;
+          }
+          if (all.length === lastCount) {
+            finishScrollCapture();
+            return;
+          }
+          stagnant = 0;
+        }
+      }
+    }
+    incrementalStopId = null;
+    incrementalStopHit = false;
+    incrementalStopSnapshotLen = null;
+    resetScrollButtonsIdle();
+  }
   function doExport() {
     window.fetch = origFetch;
     XMLHttpRequest.prototype.open = origOpen;
     XMLHttpRequest.prototype.send = origSend;
-    [btn, autoBtn].forEach(el => { try { document.body.removeChild(el); } catch (e) { } });
+    [btn, autoBtn, incBtn].forEach(el => { try { document.body.removeChild(el); } catch (e) { } });
     if (!all.length) { alert(`No ${label} captured. Use Auto-scroll or scroll manually first.`); return; }
     const blob = new Blob([JSON.stringify({ bookmarks: all, source }, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -77,59 +187,25 @@
     console.log(`✅ Downloaded ${all.length} ${label}!`);
   }
   btn.onclick = doExport;
-  const autoBtn = document.createElement('button');
-  autoBtn.textContent = '▶ Auto-scroll';
-  Object.assign(autoBtn.style, {
-    position: 'fixed', top: '58px', right: '12px', zIndex: '2147483647',
-    padding: '8px 14px', background: '#18181b', color: '#a1a1aa',
-    border: '1px solid #3f3f46', borderRadius: '8px', cursor: 'pointer',
-    fontSize: '12px', fontWeight: '600', fontFamily: 'system-ui,sans-serif'
-  });
-  let autoScrolling = false;
-  const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-  async function runAutoScroll() {
-    let stagnant = 0, lastCount = all.length;
-    while (autoScrolling) {
-      window.scrollTo(0, document.documentElement.scrollHeight);
-      const col = document.querySelector('[data-testid="primaryColumn"]');
-      col?.scrollTo(0, col.scrollHeight);
-      await sleep(900);
-      if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
-      else {
-        stagnant++;
-        if (stagnant >= 8) {
-          window.scrollTo(0, document.documentElement.scrollHeight);
-          await sleep(2000);
-          if (all.length === lastCount) {
-            autoScrolling = false;
-            autoBtn.textContent = `✅ Done — ${all.length} captured`;
-            autoBtn.style.cssText += ';background:#14532d;color:#86efac;border:1px solid #166534';
-            let sentToOpener = false;
-            try {
-              if (window.opener && !window.opener.closed) {
-                window.opener.postMessage({ type: 'SIFTLY_BOOKMARK_CAPTURE', bookmarks: all, source }, '*');
-                sentToOpener = true;
-                autoBtn.textContent = `✅ Done — ${all.length} captured and importing to Siftly.`;
-              }
-            } catch { /* ignore */ }
-            console.log(sentToOpener
-              ? `✅ Sent ${all.length} ${label} to Siftly.`
-              : `✅ Auto-scroll complete! ${all.length} ${label} ready. Click Export.`);
-            return;
-          }
-          stagnant = 0;
-        }
-      }
-    }
-    autoBtn.textContent = '▶ Auto-scroll';
-    autoBtn.style.background = '#18181b'; autoBtn.style.color = '#a1a1aa'; autoBtn.style.border = '1px solid #3f3f46';
-  }
   autoBtn.onclick = function () {
     if (autoScrolling) { autoScrolling = false; return; }
     autoScrolling = true;
     autoBtn.textContent = '⏸ Stop';
     autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
-    runAutoScroll();
+    incBtn.style.background = '#4f46e5'; incBtn.style.color = '#fff'; incBtn.style.border = 'none';
+    runAutoScroll(null);
+  };
+  incBtn.onclick = function () {
+    if (autoScrolling) { autoScrolling = false; return; }
+    if (!lastImportedTweetIdFromOpener) {
+      alert('No last import ID — complete an import from Siftly first, or use full Auto-scroll.');
+      return;
+    }
+    autoScrolling = true;
+    autoBtn.textContent = '⏸ Stop';
+    autoBtn.style.background = '#4f46e5'; autoBtn.style.color = '#fff'; autoBtn.style.border = 'none';
+    incBtn.style.background = '#4f46e5'; incBtn.style.color = '#fff'; incBtn.style.border = 'none';
+    runAutoScroll(lastImportedTweetIdFromOpener);
   };
   document.body.appendChild(btn);
   document.body.appendChild(autoBtn);
@@ -159,5 +235,24 @@
     }
     return origSend.apply(this, args);
   };
+  try {
+    if (window.opener && !window.opener.closed) {
+      function onLastIdReply(e) {
+        if (e.data?.type === 'SIFTLY_LAST_JOB_FIRST_TIMELINE_REPLY') {
+          window.removeEventListener('message', onLastIdReply);
+          const tid = isLikes
+            ? (typeof e.data.likeTweetId === 'string' && e.data.likeTweetId ? e.data.likeTweetId : (typeof e.data.tweetId === 'string' ? e.data.tweetId : ''))
+            : (typeof e.data.bookmarkTweetId === 'string' && e.data.bookmarkTweetId ? e.data.bookmarkTweetId : (typeof e.data.tweetId === 'string' ? e.data.tweetId : ''));
+          if (tid) {
+            lastImportedTweetIdFromOpener = tid;
+            document.body.appendChild(incBtn);
+          }
+        }
+      }
+      window.addEventListener('message', onLastIdReply);
+      window.opener.postMessage({ type: 'SIFTLY_LAST_JOB_FIRST_TIMELINE_QUERY' }, '*');
+      setTimeout(() => window.removeEventListener('message', onLastIdReply), 8000);
+    }
+  } catch { /* ignore */ }
   console.log(`✅ Script active. Scroll through your ${label}, then click the purple button.`);
 })();


### PR DESCRIPTION
This PR depends on https://github.com/viperrcrypto/Siftly/pull/80

## Summary

After a **bookmarks** or **likes** JSON file import, when the user opens X from Siftly in a linked window and runs the capture scripts, they can ask Siftly for the tweet ID we resolve as the **first tweet ID in timeline order** within the latest completed job’s import window—in plain terms, that ID identifies **the most recently imported bookmark** (for that job type). 

Auto-scroll can then **stop once the timeline has reached that bookmark**, instead of always scrolling all the way to the end of the feed. Full “scroll to the bottom” behavior remains available separately when you want to capture everything.

## Changes

- **Linked window + `postMessage`**: X runs in a window opened from the import page; captures are sent back via `SIFTLY_BOOKMARK_CAPTURE` and `window.opener`, and the import page `message` listener feeds the same `handleFile` path as file uploads.
- **New API** `GET /api/import/last-job-first-timeline-tweets`: for the latest `done` jobs whose filenames look like `bookmarks-*.json` / `likes-*.json`, finds bookmarks with `importedAt` in the job’s `[createdAt, updatedAt]` window, ordered by `importedAt` ascending, and returns the first row’s `tweetId` as `bookmarkTweetId` / `likeTweetId`.
- **Scripts**: `import-bookmarklet.js` and `import-console.js` send `SIFTLY_LAST_JOB_FIRST_TIMELINE_QUERY` when `opener` exists, handle `SIFTLY_LAST_JOB_FIRST_TIMELINE_REPLY`, and expose incremental auto-scroll vs full auto-scroll.
- **Parsing**: `isTweetObj` requires legacy `full_text`/`text` to filter out non-tweet objects (e.g. cards); fixes extraction of user author, handle, and avatar.
