### PR TITLE
fix: skip invalid entries from JSON imports + bump CLI timeout

### DIFF
--- a/lib/categorizer.ts
+++ b/lib/categorizer.ts
@@ -244,7 +244,10 @@ export async function categorizeBatch(
   // Prefer CLI over SDK (avoids OAuth token extraction, uses CLI directly)
   if (provider === 'openai') {
     if (await getCodexCliAvailability()) {
-      const result = await codexPrompt(prompt, { timeoutMs: 60_000 })
+      // 60s is too short once the prompt grows (many categories, image OCR text,
+      // non-English bookmarks). A 20-bookmark batch routinely needs >60s on the
+      // CLI path -> hitting the timeout drops the whole batch to the SDK fallback.
+      const result = await codexPrompt(prompt, { timeoutMs: 180_000 })
       if (result.success && result.data) {
         try {
           return parseCategorizationResponse(result.data, new Set(allSlugs))
@@ -260,7 +263,8 @@ export async function categorizeBatch(
       const model = await getActiveModel()
       const cliModel = modelNameToCliAlias(model)
 
-      const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 60_000 })
+      // See note above on codexPrompt — same reasoning for the Claude CLI path.
+      const result = await claudePrompt(prompt, { model: cliModel, timeoutMs: 180_000 })
       if (result.success && result.data) {
         try {
           return parseCategorizationResponse(result.data, new Set(allSlugs))

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -148,15 +148,34 @@ function parseSingleTweet(tweet: RawTweet): ParsedBookmark | null {
   const tweetId = extractTweetId(tweet)
   if (!tweetId) return null
 
+  // Skip entries that some JSON exports include but that the AI pipeline can
+  // never enrich (0 semantic tags -> they end up force-classified as "general"):
+  //  - preview cards captured as tweets (id_str prefixed "card://")
+  //  - the id is a t.co URL string instead of a numeric id (extraction error in the export)
+  //  - deleted/inaccessible tweets where the export only kept an id (empty text AND no user data;
+  //    note some exports write the literal "unknown" as screen_name)
+  //  - quote-tweets that are just a bare t.co URL with no media (no usable signal at all)
+  if (tweetId.startsWith('card://')) return null
+  if (tweetId.startsWith('http://') || tweetId.startsWith('https://') || tweetId.startsWith('t.co/')) return null
+
+  const text = extractText(tweet)
+  const handle = tweet.user?.screen_name
+  const hasUser = !!((handle && handle !== 'unknown') || tweet.user?.name)
+  if (text === '' && !hasUser) return null
+
+  const media = extractMedia(tweet)
+  const isUrlOnly = /^https?:\/\/t\.co\/\S+\s*$/.test(text)
+  if (isUrlOnly && media.length === 0) return null
+
   return {
     tweetId,
-    text: extractText(tweet),
+    text,
     authorHandle: extractAuthorHandle(tweet),
     authorName: extractAuthorName(tweet),
     tweetCreatedAt: extractCreatedAt(tweet),
     hashtags: extractHashtags(tweet),
     urls: extractUrls(tweet),
-    media: extractMedia(tweet),
+    media,
     rawJson: JSON.stringify(tweet),
   }
 }


### PR DESCRIPTION
## Summary

Two small fixes hardening the JSON import path. Both have been running in production on a fork for ~3 weeks across many imports.

### 1. `fix(parser)` — skip invalid entries from JSON exports

Some bookmark JSON exports include entries that the AI pipeline can never enrich — they produce **0 semantic tags** and get force-classified as `general`. On one real import this was ~25% of the batch instead of the usual ~5% floor. Four profiles, now skipped early in `parseSingleTweet()`:

- **preview cards captured as tweets** — `id_str` prefixed `"card://"`
- **id is a t.co URL string** instead of a numeric id (extraction error in the export) — `id_str` starts with `http://` / `https://` / `t.co/`
- **deleted/inaccessible tweets** where the export only kept an id — empty text **and** no user data (some exports write the literal `"unknown"` as `screen_name`, handled too)
- **quote-tweets that are just a bare t.co URL with no media** — no usable signal at all (`text` matches `^https?://t\.co/\S+$` and `extractMedia()` returns `[]`)

No behaviour change for valid tweets. This overlaps in spirit with #81's `isTweetObj` change (requiring `legacy.full_text`/`text` to filter out non-tweet objects like cards) — same problem, different angle.

### 2. `fix(categorizer)` — bump CLI timeout 60s → 180s

A 20-bookmark categorization batch routinely needs more than 60s on the CLI path once the prompt grows (many categories, image OCR text, non-English bookmarks). When it times out, the whole batch silently drops to the SDK fallback. Raised to 180s for both the Codex and Claude CLI calls.

## Test plan

- [ ] Import a JSON export that contains `card://` entries / t.co-as-id entries / empty `unknown` entries → those are skipped, valid tweets still imported
- [ ] Import a normal export → unchanged counts vs before
- [ ] Type-check passes (CI) — note: the two pre-existing TS errors in `app/api/import/x-oauth/fetch/route.ts` are unrelated to this PR
- [ ] Categorize a large batch on the CLI path → no 60s timeout, no spurious SDK fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
