### PR TITLE
fix: auto-scroll gives up too early on large bookmark libraries

### DIFF
--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -158,9 +158,19 @@ const BOOKMARKLET_SCRIPT = `(async function(){
       if(all.length>lastCount){stagnant=0;lastCount=all.length;}
       else{
         stagnant++;
-        if(stagnant>=8){
+        // Loading often pauses for many seconds (rate limits, slow fetches);
+        // nudge the timeline up and back down to retrigger loading instead of giving up.
+        if(stagnant%10===0&&stagnant<40){
+          window.scrollTo(0,Math.max(0,document.documentElement.scrollHeight-2600));
+          if(col)col.scrollTo(0,Math.max(0,col.scrollHeight-2600));
+          await sleep(1200);
           window.scrollTo(0,document.documentElement.scrollHeight);
-          await sleep(2000);
+          if(col)col.scrollTo(0,col.scrollHeight);
+          await sleep(3000);
+        }
+        if(stagnant>=40){
+          window.scrollTo(0,document.documentElement.scrollHeight);
+          await sleep(5000);
           if(all.length===lastCount){
             autoScrolling=false;
             autoBtn.textContent='\u2705 Done \u2014 '+all.length+' captured';
@@ -295,9 +305,19 @@ const CONSOLE_SCRIPT = `(async function() {
       if (all.length > lastCount) { stagnant = 0; lastCount = all.length; }
       else {
         stagnant++;
-        if (stagnant >= 8) {
+        // Loading often pauses for many seconds (rate limits, slow fetches);
+        // nudge the timeline up and back down to retrigger loading instead of giving up.
+        if (stagnant % 10 === 0 && stagnant < 40) {
+          window.scrollTo(0, Math.max(0, document.documentElement.scrollHeight - 2600));
+          col?.scrollTo(0, Math.max(0, col.scrollHeight - 2600));
+          await sleep(1200);
           window.scrollTo(0, document.documentElement.scrollHeight);
-          await sleep(2000);
+          col?.scrollTo(0, col.scrollHeight);
+          await sleep(3000);
+        }
+        if (stagnant >= 40) {
+          window.scrollTo(0, document.documentElement.scrollHeight);
+          await sleep(5000);
           if (all.length === lastCount) {
             autoScrolling = false;
             autoBtn.textContent = \`✅ Done — \${all.length} captured\`;


### PR DESCRIPTION
## Summary
Auto-scroll stops after ~9 seconds without new items (8 stagnant cycles + one 2s recheck). X's timeline regularly pauses loading for longer than that (rate limiting, slow fetches), so exports of large libraries stop far before the end. On an ~8,000-bookmark account, the current logic captured only 1,961 items (~25%) before declaring completion.

## Changes
- Wait through stalls for up to ~45s before declaring completion (both `BOOKMARKLET_SCRIPT` and `CONSOLE_SCRIPT` in `app/import/page.tsx`)
- Every ~10 stagnant cycles, nudge the timeline (scroll up ~2600px, then back down) to retrigger X's infinite loading
- Final recheck wait extended from 2s to 5s

## Related Issues
None

## Checklist
- [x] Tested locally — on the same ~8,000-bookmark account, the old logic stopped at 1,961 items; with this change auto-scroll recovered from multiple multi-second stalls and exported all ~7,800 bookmarks down to 2015
- [x] `npx tsc --noEmit` — no new errors introduced (the 2 pre-existing errors in `app/api/import/x-oauth/fetch/route.ts` are present on `main` as well)
- [x] No new warnings