### PR TITLE
Make vision analysis max_tokens configurable via VISION_MAX_TOKENS env

### DIFF
--- a/lib/vision-analyzer.ts
+++ b/lib/vision-analyzer.ts
@@ -70,6 +70,14 @@ Rules:
 const RETRY_DELAYS_MS = [1500, 4000, 10000]
 const CONCURRENCY = 12
 
+// Output budget for one image analysis. Text-dense images (infographics,
+// slides, long screenshots) can need well over 700 tokens for the full
+// text_ocr transcription; when the response is cut off mid-JSON
+// (finish_reason: length) the no-JSON path below returns '' and the item
+// is marked '{}' as attempted, so the truncation is silent. Raise via env
+// when analyzing text-heavy collections or using verbose local models.
+const VISION_MAX_TOKENS = Number(process.env.VISION_MAX_TOKENS ?? 700)
+
 /**
  * CLI-based vision analysis: passes the image URL in the prompt text.
  * Works with Codex CLI (ChatGPT OAuth) and Claude CLI without needing SDK access.
@@ -117,7 +125,7 @@ async function analyzeImageWithRetry(
   try {
     const response = await client.createMessage({
       model,
-      max_tokens: 700,
+      max_tokens: VISION_MAX_TOKENS,
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## Problem

`lib/vision-analyzer.ts` hardcodes `max_tokens: 700` for the per-image analysis call. Text-dense images (infographics, slide screenshots, long UI captures) routinely need more than 700 output tokens to complete the `text_ocr` transcription the analysis prompt asks for.

When the budget runs out, the model stops mid-JSON with `finish_reason: length`. If the truncated text contains no closing brace, the no-JSON path returns `''`, and `analyzeItem` marks the row `imageTags='{}'` as attempted. The failure is completely silent: nothing is logged, the item reads as analyzed, + it is skipped on every later run.

## Observed

Against a 9-panel infographic bookmark (via a local model served through `OPENAI_BASE_URL`): 700 tokens truncated at 2,530 characters of OCR output + silently poisoned the row. The same image completed cleanly at 2,000 tokens with a 3,873-character result.

## Change

One-line mechanism plus a comment: hoist the literal into `VISION_MAX_TOKENS = Number(process.env.VISION_MAX_TOKENS ?? 700)`. Default stays 700, so existing installs are unchanged; setting the env var raises the budget for text-heavy collections or verbose local models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)